### PR TITLE
Remove unnecessary composer-install from up target

### DIFF
--- a/idc.Makefile
+++ b/idc.Makefile
@@ -60,7 +60,7 @@ snapshot-empty:
 
 .PHONY: up
 .SILENT: up
-up:  download-default-certs docker-compose.yml start composer-install
+up:  download-default-certs docker-compose.yml start
 
 
 .PHONY: start


### PR DESCRIPTION
The container will perform `composer install` on boot, so it's redundant to invoke it again as a make target.  

`composer install` is idempotent, so it doesn't cause a problem per se, but it does take cycles.