### PR TITLE
Inital tag for buildkit images: replace 'latest' with 'upstream-20200824-f8d1e8e-10-g058b09b'

### DIFF
--- a/.env
+++ b/.env
@@ -63,7 +63,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=latest
+TAG=upstream-20200824-f8d1e8e-10-g058b09b
 
 # Docker image and tag for snapshot image
 SNAPSHOT_IMAGE=snapshot


### PR DESCRIPTION
# To test

1. Stop everything, destroy state:`docker-compose down -v`
1. Optionally remove existing buildkit images using `docker rmi`
1. Check out this pr
1. make -B docker-compose.yml pull
1. docker-compose up -d
1. Observe the `IMAGE` column of `docker ps` will include images tagged as `upstream-20200824-f8d1e8e-10-g058b09b`
