### PR TITLE
Snapshot fixes

### DIFF
--- a/.env
+++ b/.env
@@ -66,5 +66,4 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-10-g058b09b
 
 # Docker image and tag for snapshot image
-SNAPSHOT_IMAGE=snapshot
 SNAPSHOT_TAG=upstream-20201007-739693ae-12-ga409e4d8.1602146397

--- a/docker-compose.idc-snapshot.yml
+++ b/docker-compose.idc-snapshot.yml
@@ -14,8 +14,7 @@ services:
     - snapshot
   snapshot:
     container_name: snapshot
-    build: ./snapshot
-    image: ${REPOSITORY}/${SNAPSHOT_IMAGE}:${SNAPSHOT_TAG}
+    image: ${REPOSITORY}/snapshot:${SNAPSHOT_TAG}
     volumes:
     - drupal-sites-data:/data/drupal
     - mariadb-data:/data/mariadb-data

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -7,7 +7,7 @@
 # otherwise we could of simply done 'hydrate' instead of update-settings-php, update-config... etc)
 .PHONY: bootstrap
 .SILENT: bootstrap
-bootstrap: default snapshot-empty destroy-state up install \
+bootstrap: snapshot-empty default destroy-state up install \
 		update-settings-php update-config-from-environment solr-cores run-islandora-migrations \
 		cache-rebuild 
 		git checkout -- .env

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -40,7 +40,7 @@ snapshot-image:
 		alpine:latest \
 		/bin/tar cvf /dump/data.tar /data
 	TAG=`git describe --tags`.`date +%s` && \
-		docker build -f snapshot/snapshot.Dockerfile -t ${SNAPSHOT_IMAGE}:$$TAG ./snapshot && \
+		docker build -t ${REPOSITORY}/snapshot:$$TAG ./snapshot && \
 		cat .env | sed s/SNAPSHOT_TAG=.*/SNAPSHOT_TAG=$$TAG/ > /tmp/.env && \
 	  cp /tmp/.env .env && \
 	  rm /tmp/.env
@@ -56,7 +56,7 @@ snapshot-empty:
       cp /tmp/.env .env && \
 	    rm /tmp/.env
 	$(MAKE) docker-compose.yml
-	docker-compose build snapshot
+	docker build -f snapshot/empty.Dockerfile -t ${REPOSITORY}/snapshot:empty ./snapshot
 
 .PHONY: up
 .SILENT: up

--- a/snapshot/Dockerfile
+++ b/snapshot/Dockerfile
@@ -1,2 +1,6 @@
 FROM alpine:latest
-COPY data/ /
+COPY data.tar /
+RUN tar xvf /data.tar -C /
+
+FROM alpine:latest
+COPY --from=0 /data/ /data

--- a/snapshot/empty.Dockerfile
+++ b/snapshot/empty.Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:latest
+COPY data/ /

--- a/snapshot/snapshot.Dockerfile
+++ b/snapshot/snapshot.Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:latest
-COPY data.tar /
-RUN tar xvf /data.tar -C /
-
-FROM alpine:latest
-COPY --from=0 /data/ /data


### PR DESCRIPTION
Fixes anomalies with snapshots that resulted in:
* empty snapshot images being build, instead of pulling existing ones
* pushing empty snapshot images instead of ones built locally

# To test

## Verify problems on `development` branch

To observe building a snapshot image rather than pulling it:
* Make sure you are on the latest `development` branch
* Remove all snapshot images via `docker rmi $(docker images | grep snapshot | awk '{print $3'})`
  * or just remove the one reverenced in `.env` if you wish
* do a `make up`
  * Observe that it _builds_ the snapshot image.  Once Drupal is built, notice that visiting https://islandora-idc.traefik.me will result in an error

To observe building an empty image instead of the desired snapshot image
* do a `docker-compose down -v`
* do a `docker-compose pull`, it will pull in the snapshot image it should have been using
* Run `make up`; it should work now!
  * confirm drupal page works https://islandora-idc.traefik.me
* Now make a snapshot `make snapshot-image`
* Once done, look a the Drupal page:  it appears to still work:  https://islandora-idc.traefik.me
* Now do a `docker-compose down -v`, then a `make up`.
* Once loaded, go to https://islandora-idc.traefik.me/  It doesn't work any more

## Verify fixes from the PR branch
Now check out the PR (discard changes to `.env`)
Repeat the above instructions from "verify problems on the `development` branch.  You should now be able to work through them successfully without error.