### PR TITLE
Build static Drupal image for cloud instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+on: push
+
+jobs:
+    everything:
+        name: Build, Test, or Deploy
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        env:
+          DOCKER_USER: ${{secrets.DOCKER_USER}}
+        steps:
+            # Check out current commit
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            # Make sure buildkit is enabled
+            - name: Enable buildkit
+              shell: bash
+              run: |
+                  echo '{"experimental": "enabled"}' > ~/.docker/config.json
+            
+            # Initially run the development environment to make sure that succeeds
+            - name: Build Dev
+              run: make up
+    
+            # Build and run the static environment
+            - name: Build Static 
+              run: docker-compose down -v && make static-docker-compose.yml up
+
+            # Log in to Docker, if we have the secrets
+            - name: Login
+              if: ${{ env.DOCKER_USER != null }}
+              uses: docker/login-action@v1
+              with:
+                registry: ghcr.io
+                username: ${{ env.DOCKER_USER }}
+                password: ${{ secrets.DOCKER_PASS }}
+            
+            # Push docker images
+            - name: Docker Push
+              if:  ${{ env.DOCKER_USER != null }}
+              run: docker-compose push drupal-static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
               run: docker-compose down -v && make static-docker-compose.yml up
 
             # Log in to Docker, if we have the secrets
-            - name: Login
+            - name: Docker Login
               if: ${{ env.DOCKER_USER != null }}
               uses: docker/login-action@v1
               with:
@@ -39,4 +39,4 @@ jobs:
             # Push docker images
             - name: Docker Push
               if:  ${{ env.DOCKER_USER != null }}
-              run: docker-compose push drupal-static
+              run: docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 
 jobs:
     everything:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ ARG REPOSITORY
 ARG TAG
 FROM ${REPOSITORY}/drupal:${TAG}
 
-COPY --chown=nginx:nginx codebase/* /var/www/drupal
+RUN --mount=type=bind,source=codebase,target=/build \
+    cp -r /build/* /var/www/drupal && \
+    cd /var/www/drupal && COMPOSER_MEMORY_LIMIT=-1 composer install && \
+    chown -R nginx:nginx /var/www/drupal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:experimental
+ARG REPOSITORY
+ARG TAG
+FROM ${REPOSITORY}/drupal:${TAG}
+
+COPY --chown=nginx:nginx codebase/* /var/www/drupal

--- a/IDC.md
+++ b/IDC.md
@@ -51,6 +51,16 @@ so no need to do anything special other than `make` to invoke them).  A few usef
 * **make snapshot** Create a snapshot of the current Drupal state (db, content files, etc), so that you can reset to this state at will, or push it so that others can.
 * **make up** Brings up the development environment, including running `composer install`.
 
+A few specialized targets are:
+
+* **make static-docker-compose.yml** Make a docker-compose.yml based off non-development "static" environment.  Notably:
+  * A `drupal-static` image is built or pulled, which has `codebase` baked in, and is used in place of the normal `drupal` image
+  * `codebase` is no longer bind mounted
+* **make static-drupal-image** builds (or pulls, if published) a "static" drupal image suitable for deployment in the cloud.  This image:
+  * Has the contents of `codebase` baked into it, as well as all dependencies via `composer install`
+  * Will load its config from `config/sync` upon startup
+  * Is named `drupal-static` and is tagged based on `git describe --tags`.  
+
 ## Snapshots
 
 Snapshots are Docker images that contain Drupal state (content files, database, SOLR indexes, Fedora files, etc).  When Docker starts,

--- a/docker-compose.static.yml
+++ b/docker-compose.static.yml
@@ -1,0 +1,34 @@
+# Container does not perform any initialization aside from importing env-vars from `confd`.
+# Users are expected to manually set up their site using a combination of the following:
+# - Makefile targets
+# - composer requires / install
+# - Drush commands
+# - Manual changes to the codebase directory
+version: "3.7"
+networks:
+  default:
+    internal: true
+  gateway:
+    external:
+      name: gateway
+volumes:
+  drupal-sites-data:
+  solr-data:
+services:
+  drupal:
+    image: ${REPOSITORY}/drupal-static:${DRUPAL_STATIC_TAG}
+    environment:
+      DRUPAL_INSTANCE: static
+    volumes:
+      - drupal-sites-data:/var/www/drupal/web/sites/default/files
+      - solr-data:/opt/solr/server/solr
+    depends_on:
+      # Requires a the very minimum a database.
+      - ${DRUPAL_DATABASE_SERVICE}
+  # Extends docker-compose.solr.yml
+  solr:
+    volumes:
+      # On a production site you may not want to take this approach but instead refer to each of the cores
+      # data directories specifically and maintain the configuration as part of a customized image, where 
+      # in your configuration is Solr managed under source control somewhere.
+      - solr-data:/opt/solr/server/solr

--- a/docker-compose.static.yml
+++ b/docker-compose.static.yml
@@ -16,6 +16,11 @@ volumes:
   solr-data:
 services:
   drupal:
+    build:
+      context: .
+      args:
+        TAG: ${TAG}
+        REPOSITORY: ${REPOSITORY}
     image: ${REPOSITORY}/drupal-static:${DRUPAL_STATIC_TAG}
     environment:
       DRUPAL_INSTANCE: static

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -117,9 +117,7 @@ static-drupal-image:
 	EXISTING=`docker images -q $$IMAGE` ; \
 	if test -z "$$EXISTING" ; then \
 	    docker pull $${IMAGE} 2>/dev/null || \
-	    docker build --build-arg REPOSITORY=${REPOSITORY} \
-	        --build-arg TAG=${TAG} \
-	        -t ${REPOSITORY}/drupal-static:${GIT_TAG} . ; \
+	    docker-compose build drupal ; \
 	else \
 	    echo "Using existing Drupal image $${EXISTING}" ; \
 	fi

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := default
-GIT_TAG := $(shell git describe --tags)
+GIT_TAG := $(shell git describe --tags --always)
 
 # Bootstrap a new instance without Fedora.  Assumes there is a Drupal site in ./codebase.
 # Will do a clean Drupal install and initialization
@@ -40,7 +40,7 @@ snapshot-image:
 		-v ${PWD}/snapshot:/dump \
 		alpine:latest \
 		/bin/tar cvf /dump/data.tar /data
-	TAG=`git describe --tags`.`date +%s` && \
+	TAG=${GIT_TAG}.`date +%s` && \
 		docker build -t ${REPOSITORY}/snapshot:$$TAG ./snapshot && \
 		cat .env | sed s/SNAPSHOT_TAG=.*/SNAPSHOT_TAG=$$TAG/ > /tmp/.env && \
 	  cp /tmp/.env .env && \

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -104,7 +104,7 @@ start:
 .SILENT: wait-for-drupal
 wait-for-drupal:
 	while test -z `docker-compose ps -q drupal` ; do echo "Waiting for Drupal container to start"; sleep 5; done
-	docker-compose exec drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to load ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"
+	docker-compose exec -T drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to load ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"
 
 # Static drupal image, with codebase baked in.  This image
 # is tagged based on the current git hash/tag.  If the image is not present

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -98,3 +98,11 @@ start:
 	docker-compose up -d
 	sleep 5
 	docker-compose exec drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to start ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"
+
+.PHONY: drupal-image
+.SILENT: drupal-image
+drupal-image:
+	DRUPAL_TAG=`git describe --tags` && \
+	    docker build --build-arg REPOSITORY=${REPOSITORY} \
+	    --build-arg TAG=${TAG}\
+	    -t ${REPOSITORY}/drupal-static:$${DRUPAL_TAG} .

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL := default
+GIT_TAG := $(shell git describe --tags)
 
 # Bootstrap a new instance without Fedora.  Assumes there is a Drupal site in ./codebase.
 # Will do a clean Drupal install and initialization
@@ -99,10 +100,41 @@ start:
 	sleep 5
 	docker-compose exec drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to start ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"
 
-.PHONY: drupal-image
-.SILENT: drupal-image
-drupal-image:
-	DRUPAL_TAG=`git describe --tags` && \
+# Static drupal image, with codebase baked in.  This image
+# is tagged based on the current git hash/tag.  If the image is not present
+# locally, nor pullable, then this is built locally.  Ultimately, this image is 
+# intended be published to cloud instances of the stack
+.PHONY: static-drupal-image
+.SILENT: static-drupal-image
+static-drupal-image:
+	IMAGE=${REPOSITORY}/drupal-static:${GIT_TAG} ; \
+	EXISTING=`docker images -q $$IMAGE` ; \
+	if test -z "$$EXISTING" ; then \
+	    docker pull $${IMAGE} 2>/dev/null || \
 	    docker build --build-arg REPOSITORY=${REPOSITORY} \
-	    --build-arg TAG=${TAG}\
-	    -t ${REPOSITORY}/drupal-static:$${DRUPAL_TAG} .
+	        --build-arg TAG=${TAG} \
+	        -t ${REPOSITORY}/drupal-static:${GIT_TAG} . ; \
+	else \
+	    echo "Using existing Drupal image $${EXISTING}" ; \
+	fi
+
+
+# Build a docker-compose file that will run the whole stack, except with
+# the static drupal image rather than the dev drupal image + codebase bind mount.  
+.SILENT: static-docker-compose.yml
+.PHONY: static-docker-compose.yml 
+static-docker-compose.yml: static-drupal-image
+	-rm -f docker-compose.yml
+	echo '' > .env_static && \
+	    while read line; do \
+		if echo $$line | grep -q "ENVIRONMENT" ; then \
+			echo "ENVIRONMENT=static" >> .env_static ; \
+		else \
+			echo $$line >> .env_static ; \
+		fi \
+	    done < .env && \
+	    echo DRUPAL_STATIC_TAG=${GIT_TAG} >> .env_static
+	mv .env .env.bak
+	mv .env_static .env
+	$(MAKE) docker-compose.yml || mv .env.bak .env
+	if [ -f .env.bak ] ; then mv .env.bak .env ; fi


### PR DESCRIPTION
## Overview
* Adds new Make targets to build a "static" drupal image with dependencies and configuration baked in, and a docker-compose.yml that will run such an environment
  * `make static-drupal-image`: builds a static Drupal image with codebase baked inside.
  * `make static-docker-compose.yml`:  builds the static Drupal image if necessary, and constructs a `docker-compose.yml` file that runs the static Drupal image instead of the buildkit image, doesn't bind mount `codebase`, and results in the Drupal image loading its config from config/sync upon startup  
* Adds github actions to build and run the local (dev) and static (cloud-like) environments

## To Test

### Static environment
* Verify that the github actions build passes
* Locally, run `make static-docker-compose.yml`.  It should successfully build a static drupal image.  The resulting `docker-compose.yml` file should reference  the image `...idc-isle-dc/drupal-static:...` for Drupal, and the bind mount directive should be gone from the `drupal` service definition
* Run `make up` and make sure it starts.  @emetsger or other mac users I'm not sure how this will play with NFS override, if you use that.  The intend is to _not_ have `codebase` mounted

### Github actions
* Push this branch to your own personal github repo
* Go to your personal repo, and click on the "actions" tab near the top.  You should see an action building:
* wait for it to complete successfully. Because you don't have secrets for Docker defined, it will skip the Docker login and Docker push steps
