### PR TITLE
Remove Fedora-specific crayfish services

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@
 # See documentation for more details.
 ENVIRONMENT=local
 
-REQUIRED_SERIVCES=activemq alpaca cantaloupe crayfish crayfits drupal mariadb matomo solr idc-snapshot testcafe
+REQUIRED_SERIVCES=activemq alpaca cantaloupe idc-crayfish crayfits drupal mariadb matomo solr idc-snapshot testcafe
 ###############################################################################
 # Environment variables specific to composer.
 ###############################################################################

--- a/docker-compose.idc-crayfish.yml
+++ b/docker-compose.idc-crayfish.yml
@@ -1,0 +1,11 @@
+version: "3.7"
+networks:
+  default:
+    internal: true
+services:
+  homarus:
+    image: ${REPOSITORY:-islandora}/homarus:${TAG:-latest}
+  houdini:
+    image: ${REPOSITORY:-islandora}/houdini:${TAG:-latest}
+  hypercube:
+    image: ${REPOSITORY:-islandora}/hypercube:${TAG:-latest}


### PR DESCRIPTION
# Overview
Because Fedora is not in our stack, we have no need for recast, gemini,
and milliner.

This PR defines an idc-specific Crayfish file that enumerates only those crayfish services we need.

Note:  the gemini database is still in place, and the Islandora bootstrap process still sets configuration values for the gemini service.  Such loose ends do not appear to affect the Drupal instance in any negative way, and can be cleaned up later.  Because the cost of such cleanups is high (editing utilities.sh in idc-isle-buildkit/drupal and adding conditionals), this will be deferred to a later task.

## To test
Remove docker-compose.yml, `make docker-compose.yml`, then bring up the stack (`make up`) and make sure it still functions.

Removal is motivated by review of stack topology in jhu-sheridan-libraries/idc-general#68