### PR TITLE
Config sync tests

### DIFF
--- a/idc.Makefile
+++ b/idc.Makefile
@@ -146,5 +146,5 @@ static-docker-compose.yml: static-drupal-image
 .SILENT: test
 .PHONY: test
 test:
-	docker-compose exec -T testcafe npm test
+	./run-tests.sh
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+
+FAIURES=''
+
+for testscript in tests/*; do
+	echo "Running ${testscript}"
+	$testscript || FAILURES="${FAILURES} $testscript";
+done
+
+if [ ! -z "${FAILURES}" ] ; then
+	echo "TESTS FAILED: ${FAILURES}"
+	exit 1
+fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,14 +1,33 @@
 #!/bin/sh
 
+if [ -t 1 ] ; then
+	echo "WARNING:  running the test suite will result in resetting the stack's state "
+	echo "to the SNAPSHOT_TAG specified in .env.  This will wipe out all local changes "
+	echo "to Drupal's databases and remove any active content or configuration added since"
+	echo "the last snapshot."
+	echo ""
+	echo "WARNING: continue? [Y/n]"
+	read line; if [ $line != "Y" ]; then echo aborting; exit 1 ; fi
+fi
 
-FAIURES=''
+reset() {
+	printf "\nResetting state to last snapshot\n"
+	docker-compose down -v 2>/dev/null
+	make -s up 2>/dev/null
+}
 
-for testscript in tests/*; do
-	echo "Running ${testscript}"
-	$testscript || FAILURES="${FAILURES} $testscript";
+for testscript in tests/*; do 
+	reset
+	printf "\n\nRunning ${testscript}\n"
+	{ $testscript && echo "PASS: $testscript"; } || { FAILURES="${FAILURES} $testscript" && echo "FAIL: $testscript";}
 done
 
+reset
+
 if [ ! -z "${FAILURES}" ] ; then
-	echo "TESTS FAILED: ${FAILURES}"
+	printf "\nFAIL: ${FAILURES}\n"
 	exit 1
 fi
+
+
+printf "\nSUCCESS: All test passed\n"

--- a/tests/01-end-to-end.sh
+++ b/tests/01-end-to-end.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker-compose exec -T testcafe npm test

--- a/tests/02-static-config.sh
+++ b/tests/02-static-config.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Verifies that bad configuration in config/sync will cause a startup failure for Docker
+
+# First, check to seee if docker-compose.yml defines DRUPAL_INSTANCE: static.  If not, we're not
+# using the static environment and should skip this test
+STATIC=`cat docker-compose.yml | grep DRUPAL_INSTANCE | grep static | wc -l`
+if [ $STATIC -lt 1 ]; then
+	echo "Skipping tests on non-static environment"
+	exit 0
+fi
+
+# corrupt a config file, stop Drupal, and start it.  Expect an error upon startup
+docker-compose exec -T drupal mv config/sync/core.extension.yml config/sync/_core.extension.yml
+echo "Corrupting the config and re-starting Drupal"
+docker-compose stop drupal 
+make up  && echo "Did not encounter error when starting Drupal with corrupt config" && exit 1
+echo "Drupal failed as expected"


### PR DESCRIPTION
* Adds tests to verify that (static) Drupal will fail to boot if there is an error syncing with config/sync.  
* re-structures tests into a series of executables (shell scripts) in `tests/`, with a `/run-tests.sh` test runner invoked by `make test`.  A poor man's test runner "framework" of sorts.

This simple test "framework" will likely require a few eyes for review.

# How it works
* `make test` invokes `./run-tests.sh`
* `/run-tests.sh` will iterate all files in `/tests` in lexically sorted order, and for each one:
  * Clear state to the last snapshot
  * Run the test script
  * Note the success or failure status (exit code from the script)
* If one or more test scripts fail, run-tests.sh will return a non-zero exit code.

`tests/01-end-to.end.sh` just runs the testcafe tests as usual:  `docker-compose exec -T testcafe npm test`

`tests/02-static-config.sh` only runs for docker-compose.yml files that indicate `static` `DRUPAL_INSTANCE`.  It exec's into the `drupal` container, corrupts the config, re-starts the container via `make up`, and expects a failure of `make up`.  

A developer can run whatever tests he or she chooses simply by, within the root directory, executing one of the test scripts, e.g. `./tests/02-static-config.sh`.

# To test
* Check CI for this PR and verify it passes
* edit .env to specify an _older_ `TAG`:  upstream-20200824-f8d1e8e-11-gb758f8b
* do `make static-docker-compose.yml`, then `make test`
* you should see a failure for `tests/02-static-config.sh`, and `make test` should have returned with an error code.  This error occurs because the older TAG will not fail if Drupal fails to load config/sync.

resolves #24 