### PR TITLE
[DO NOT MERGE] experimenting to check out a strange failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,7 @@ jobs:
             # Log in to Docker, if we have the secrets
             - name: Docker Login
               if: ${{ env.DOCKER_USER != null }}
-              uses: docker/login-action@v1
-              with:
-                registry: ghcr.io
-                username: ${{ env.DOCKER_USER }}
-                password: ${{ secrets.DOCKER_PASS }}
+              run: echo '${{ env.DOCKER_USER }}'
             
             # Push docker images
             - name: Docker Push


### PR DESCRIPTION
For some reason, Bethany's pull request ran the 'docker login' step.   It's supposed to be excluded unless the DOCKER_USER is exposed.  For PRs, DOCKER_USER should not be exposed.  Since ` ${{ env.DOCKER_USER != null }}` for Bethany's PR, I'd like to see if I can reproduce the phenomenon here and and see what its value is...