### PR TITLE
Pull in Taxonomy RDF mapping changes as well as make JSON-LD for reference_value_pair better

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-110-g517f87b.1609797489
+SNAPSHOT_TAG=upstream-20201007-739693ae-123-g0dd0f5b.1610143543
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -6119,12 +6119,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/controlled_access_terms.git",
-                "reference": "0fc1713f2ba544ad38118067dea12367bf02e512"
+                "reference": "b615269cb146880d15f88d0b1d8dd9d09eed3ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/controlled_access_terms/zipball/0fc1713f2ba544ad38118067dea12367bf02e512",
-                "reference": "0fc1713f2ba544ad38118067dea12367bf02e512",
+                "url": "https://api.github.com/repos/jhu-idc/controlled_access_terms/zipball/b615269cb146880d15f88d0b1d8dd9d09eed3ef2",
+                "reference": "b615269cb146880d15f88d0b1d8dd9d09eed3ef2",
                 "shasum": ""
             },
             "require": {
@@ -6166,7 +6166,7 @@
                 "issues": "https://github.com/jhu-idc/controlled_access_terms/issues",
                 "source": "https://github.com/jhu-idc/controlled_access_terms/tree/8.x-1.x"
             },
-            "time": "2020-12-21T19:28:44+00:00"
+            "time": "2021-01-08T18:48:20+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",
@@ -6174,12 +6174,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/islandora_defaults.git",
-                "reference": "5618d8b38199829e81b07dc301967577430260d6"
+                "reference": "c8d4bab574688d9626144b2bcc3b4753ee6eb8e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/islandora_defaults/zipball/5618d8b38199829e81b07dc301967577430260d6",
-                "reference": "5618d8b38199829e81b07dc301967577430260d6",
+                "url": "https://api.github.com/repos/jhu-idc/islandora_defaults/zipball/c8d4bab574688d9626144b2bcc3b4753ee6eb8e3",
+                "reference": "c8d4bab574688d9626144b2bcc3b4753ee6eb8e3",
                 "shasum": ""
             },
             "require": {
@@ -6205,7 +6205,7 @@
                 "issues": "https://github.com/jhu-idc/islandora_defaults/issues",
                 "source": "https://github.com/jhu-idc/islandora_defaults/tree/8.x-1.x"
             },
-            "time": "2021-01-04T21:31:49+00:00"
+            "time": "2021-01-08T18:46:01+00:00"
         },
         {
             "name": "jhu-idc/reference_value_pair",
@@ -6213,12 +6213,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/reference_value_pair.git",
-                "reference": "0a75d201b6d512672e7a0466f4e8cd3111f3d24d"
+                "reference": "7b563f97e752c69d45465208424415472785bec9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/reference_value_pair/zipball/0a75d201b6d512672e7a0466f4e8cd3111f3d24d",
-                "reference": "0a75d201b6d512672e7a0466f4e8cd3111f3d24d",
+                "url": "https://api.github.com/repos/jhu-idc/reference_value_pair/zipball/7b563f97e752c69d45465208424415472785bec9",
+                "reference": "7b563f97e752c69d45465208424415472785bec9",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -6234,7 +6234,7 @@
                 "issues": "http://github.com/jhu-idc/reference_value_pair",
                 "source": "http://github.com/jhu-idc/reference_value_pair"
             },
-            "time": "2020-12-07T17:45:39+00:00"
+            "time": "2021-01-08T18:41:14+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -6119,12 +6119,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/controlled_access_terms.git",
-                "reference": "b615269cb146880d15f88d0b1d8dd9d09eed3ef2"
+                "reference": "b2c3e6c56b00a68f0e13f6717788710bb2329ab0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/controlled_access_terms/zipball/b615269cb146880d15f88d0b1d8dd9d09eed3ef2",
-                "reference": "b615269cb146880d15f88d0b1d8dd9d09eed3ef2",
+                "url": "https://api.github.com/repos/jhu-idc/controlled_access_terms/zipball/b2c3e6c56b00a68f0e13f6717788710bb2329ab0",
+                "reference": "b2c3e6c56b00a68f0e13f6717788710bb2329ab0",
                 "shasum": ""
             },
             "require": {
@@ -6166,7 +6166,7 @@
                 "issues": "https://github.com/jhu-idc/controlled_access_terms/issues",
                 "source": "https://github.com/jhu-idc/controlled_access_terms/tree/8.x-1.x"
             },
-            "time": "2021-01-08T18:48:20+00:00"
+            "time": "2021-01-08T21:57:04+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",
@@ -6213,12 +6213,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/reference_value_pair.git",
-                "reference": "7b563f97e752c69d45465208424415472785bec9"
+                "reference": "50bf98c092133d70e9261cd2ab4717f1dd75f453"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/reference_value_pair/zipball/7b563f97e752c69d45465208424415472785bec9",
-                "reference": "7b563f97e752c69d45465208424415472785bec9",
+                "url": "https://api.github.com/repos/jhu-idc/reference_value_pair/zipball/50bf98c092133d70e9261cd2ab4717f1dd75f453",
+                "reference": "50bf98c092133d70e9261cd2ab4717f1dd75f453",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -6234,7 +6234,7 @@
                 "issues": "http://github.com/jhu-idc/reference_value_pair",
                 "source": "http://github.com/jhu-idc/reference_value_pair"
             },
-            "time": "2021-01-08T18:41:14+00:00"
+            "time": "2021-01-08T22:06:46+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",

--- a/codebase/config/sync/core.entity_form_display.taxonomy_term.language.default.yml
+++ b/codebase/config/sync/core.entity_form_display.taxonomy_term.language.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.language.field_authority_link
+    - field.field.taxonomy_term.language.field_language_code
     - taxonomy.vocabulary.language
   module:
     - controlled_access_terms
@@ -18,30 +19,38 @@ mode: default
 content:
   description:
     type: text_textarea
-    weight: 0
+    weight: 2
     region: content
     settings:
       placeholder: ''
       rows: 5
     third_party_settings: {  }
   field_authority_link:
-    weight: 31
+    weight: 3
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: authority_link_default
     region: content
+  field_language_code:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
-    weight: 99
+    weight: 6
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   name:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -49,7 +58,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 97
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -57,11 +66,11 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 7
     region: content
     third_party_settings: {  }
   translation:
-    weight: 98
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/codebase/config/sync/core.entity_view_display.taxonomy_term.language.default.yml
+++ b/codebase/config/sync/core.entity_view_display.taxonomy_term.language.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.language.field_authority_link
+    - field.field.taxonomy_term.language.field_language_code
     - taxonomy.vocabulary.language
   module:
     - controlled_access_terms
@@ -45,6 +46,14 @@ content:
       target: _blank
     third_party_settings: {  }
     type: authority_formatter_default
+    region: content
+  field_language_code:
+    weight: 2
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
 hidden:
   langcode: true

--- a/codebase/config/sync/field.field.taxonomy_term.language.field_language_code.yml
+++ b/codebase/config/sync/field.field.taxonomy_term.language.field_language_code.yml
@@ -1,0 +1,19 @@
+uuid: 7651b49b-32a8-402a-941a-a0c0ad4f179c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_language_code
+    - taxonomy.vocabulary.language
+id: taxonomy_term.language.field_language_code
+field_name: field_language_code
+entity_type: taxonomy_term
+bundle: language
+label: 'Language Code'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.storage.taxonomy_term.field_language_code.yml
+++ b/codebase/config/sync/field.storage.taxonomy_term.field_language_code.yml
@@ -1,0 +1,25 @@
+uuid: 4923c3ba-c712-4b38-8765-953dacbd7fbd
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_language_code
+field_name: field_language_code
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 16
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This PR completes changes on the RDF mapping for taxonomy terms (located in updated controlled_access_terms repository) as well as fixes how the JSON-LD renders for reference_value_pairs (this does not fix the fact that a reference_value_pair is not bound to the language taxonomy - I will fix that in a later PR). 

This PR adds a new field to the Language Taxonomy so admin users can add a ISO-639-2 language abbreviation to the Language Term (or really any lang codes that satisfy the JSON-LD language code criteria.  The metadata group talked about using ISO-639-2 from the LOC).  That field's value is used in the JSON-LD.   (I wank to ack. that this may not be the best technical method to do this and am open to ideas). 

The JSON-LD for a reference_value_pair now looks like this:  

```
"http://purl.org/dc/terms/alternative": [

    {
        "@value": "Alternative Title",
        "@language": "eng"
    },
    {
        "@value": "Alternativ",
        "@language": "ger"
    }

],
```

This fixes https://github.com/jhu-idc/idc-isle-dc/issues/39  and https://github.com/jhu-idc/idc-isle-dc/issues/37