### PR TITLE
Use SQL dumps for snapshots

### DIFF
--- a/.env
+++ b/.env
@@ -76,3 +76,6 @@ SP_BASEURL=https://islandora-idc.traefik.me
 SP_ENTITYID=https://islandora-idc.traefik.me/sp/shibboleth
 IDP_BASEURL=https://islandora-idp.traefik.me:4443
 IDP_ENTITYID=https://islandora-idp.traefik.me/idp/shibboleth
+
+# DB params
+DRUPAL_DEFAULT_DB_PASSWORD=password

--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-141-ga28f4f5.1611599337
+SNAPSHOT_TAG=upstream-20201007-739693ae-144-g5d7ff89.1611866437
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/docker-compose.env.yml
+++ b/docker-compose.env.yml
@@ -95,7 +95,7 @@ services:
       #
       # The password Drupal uses to connect to the database for the default site.
       #
-      DRUPAL_DEFAULT_DB_PASSWORD: password
+      DRUPAL_DEFAULT_DB_PASSWORD: ${DRUPAL_DEFAULT_DB_PASSWORD}
       #
       # Must match MYSQL_ROOT_PASSWORD, used to create the database / user.
       #

--- a/docker-compose.idc-snapshot.yml
+++ b/docker-compose.idc-snapshot.yml
@@ -16,8 +16,6 @@ services:
     image: ${REPOSITORY}/snapshot:${SNAPSHOT_TAG}
     volumes:
     - drupal-sites-data:/data/drupal
-    - mariadb-data:/data/mariadb-data
-    - mariadb-files:/data/mariadb-files
     - mariadb-dump:/data/mariadb-dump
     - solr-data:/data/solr
 volumes:

--- a/docker-compose.idc-snapshot.yml
+++ b/docker-compose.idc-snapshot.yml
@@ -4,6 +4,8 @@ services:
     depends_on:
     - snapshot
   mariadb:
+    volumes:
+    - mariadb-dump:/mariadb-dump
     depends_on:
     - snapshot
   solr:
@@ -16,4 +18,7 @@ services:
     - drupal-sites-data:/data/drupal
     - mariadb-data:/data/mariadb-data
     - mariadb-files:/data/mariadb-files
+    - mariadb-dump:/data/mariadb-dump
     - solr-data:/data/solr
+volumes:
+  mariadb-dump:

--- a/docker-compose.idc-snapshot.yml
+++ b/docker-compose.idc-snapshot.yml
@@ -17,6 +17,10 @@ services:
     volumes:
     - drupal-sites-data:/data/drupal
     - mariadb-dump:/data/mariadb-dump
+    # Uncomment to use binary mysql db in snapshot image, if needed. 
+    # Mostly helpful in cases where it's necessary to run an old-style 
+    # snapshot image that has binary mysql db, but no sql dump
+    # - mariadb-data:/data/mariadb-data
     - solr-data:/data/solr
 volumes:
   mariadb-dump:

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -115,19 +115,12 @@ start:
 		if [ ! -n "$$BASIC_DBS_PRESENT" ]; then continue; fi; \
 		if [ "$$BASIC_DBS_PRESENT" -gt "0" ]; then echo "Connection established!" && break; fi; \
 	done; \
-	echo "foo"; \
 	DRUPAL_STATE_EXISTS=$$(docker-compose exec -T mariadb mysql mysql -N -e "SELECT count(*) from information_schema.SCHEMATA WHERE schema_name = 'drupal_default';"); \
-	DUMP_FILES_FOUND=$$(docker-compose exec -T mariadb bash -c 'ls -l /mariadb-dump/*.sql | wc -l'); \
 	if [ $${DRUPAL_STATE_EXISTS} != "1" ] ; then \
 		echo "No Drupal state found"; \
 		${MAKE} db_restore; \
-	else  \
-		if [ $${DUMP_FILES_FOUND} = "0" ] ; then \ 
-			echo "WARNING:  this is an old-style snapshot, using direct mysql data image"; \
-		else \
-			echo "Pre-existing Drupal state found, not loading db from snapshot"; \
-		fi; \
-	fi
+	else echo "Pre-existing Drupal state found, not loading db from snapshot"; \
+	fi;
 	docker-compose up -d
 	sleep 5
 	docker-compose exec -T drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to start ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -35,6 +35,7 @@ composer-install:
 .PHONY: snapshot-image
 .SILENT: snapshot-image
 snapshot-image:
+	${MAKE} db_dump
 	docker-compose stop
 	docker run --rm --volumes-from snapshot \
 		-v ${PWD}/snapshot:/dump \
@@ -62,7 +63,7 @@ reset: warning-destroy-state destroy-state
 	$(MAKE) docker-compose.yml
 	@echo "Starting ..."
 	@echo "Invoke 'docker-compose logs -f drupal' in another terminal to monitor startup progress"
-	$(MAKE) start
+	$(MAKE) up
 
 .PHONY: warning-destroy-state
 .SILENT: warning-destroy-state
@@ -98,10 +99,35 @@ snapshot-push:
 .SILENT: up
 up:  download-default-certs docker-compose.yml start
 
-
 .PHONY: start
 .SILENT: start
 start:
+	docker-compose up -d mariadb snapshot;
+	# Try connecting to mysql, and get a valid (a number, greater than zero) count of the number of databases.
+	# Then, once we're confident that mysql up and validly query able, see if the Drupal db is in place.  
+	# If not, then load it from snapshot before starting the stack.  Otherwise, if the Drupal db is already
+	# present, just start.
+	for i in $$(seq 5) ; do \
+		echo "waiting for mysql to start..."; \
+		sleep 5; \
+		BASIC_DBS_PRESENT=$$(docker-compose exec -T mariadb mysql mysql -N -e "SELECT count(*) from information_schema.SCHEMATA;"); \
+		if [  "$$?" -gt "0" ]; then continue; fi; \
+		if [ ! -n "$$BASIC_DBS_PRESENT" ]; then continue; fi; \
+		if [ "$$BASIC_DBS_PRESENT" -gt "0" ]; then echo "Connection established!" && break; fi; \
+	done; \
+	echo "foo"; \
+	DRUPAL_STATE_EXISTS=$$(docker-compose exec -T mariadb mysql mysql -N -e "SELECT count(*) from information_schema.SCHEMATA WHERE schema_name = 'drupal_default';"); \
+	DUMP_FILES_FOUND=$$(docker-compose exec -T mariadb bash -c 'ls -l /mariadb-dump/*.sql | wc -l'); \
+	if [ $${DRUPAL_STATE_EXISTS} != "1" ] ; then \
+		echo "No Drupal state found"; \
+		${MAKE} db_restore; \
+	else  \
+		if [ $${DUMP_FILES_FOUND} = "0" ] ; then \ 
+			echo "WARNING:  this is an old-style snapshot, using direct mysql data image"; \
+		else \
+			echo "Pre-existing Drupal state found, not loading db from snapshot"; \
+		fi; \
+	fi
 	docker-compose up -d
 	sleep 5
 	docker-compose exec -T drupal /bin/sh -c "while true ; do echo \"Waiting for Drupal to start ...\" ; if [ -d \"/var/run/s6/services/nginx\" ] ; then s6-svwait -u /var/run/s6/services/nginx && exit 0 ; else sleep 5 ; fi done"
@@ -147,4 +173,21 @@ static-docker-compose.yml: static-drupal-image
 .PHONY: test
 test:
 	./run-tests.sh
+
+.PHONY: db_dump
+.SILENT: db_dump
+db_dump:
+	docker-compose exec -T mariadb bash -c "mysqldump --databases drupal_default --add-drop-database > /mariadb-dump/drupal_default.sql"
+
+.PHONY: db_restore
+.SILENT: db_restore
+db_restore:
+	if [ -z "${DRUPAL_DEFAULT_DB_USER}" ] ; then \
+		DRUPAL_DEFAULT_DB_USER=drupal_default; \
+	fi; \
+	echo "Creating mysql user $${DRUPAL_DEFAULT_DB_USER}"
+	docker-compose exec -T mariadb mysql mysql -e "CREATE USER IF NOT EXISTS '$${DRUPAL_DEFAULT_DB_USER}'@'%' IDENTIFIED BY '${DRUPAL_DEFAULT_DB_PASSWORD}'; FLUSH PRIVILEGES"; \
+	echo "Loading mysql dump"; \
+		docker-compose exec -T mariadb bash -c 'mysql mysql < /mariadb-dump/drupal_default.sql'; \
+	docker-compose exec -T mariadb mysql mysql -e "GRANT ALL PRIVILEGES ON drupal_default.* to '$${DRUPAL_DEFAULT_DB_USER}'@'%';";
 


### PR DESCRIPTION
This will make the development snapshot mechanism compatible and analogous to the current proposed cloud init mechanism.  

In particular:
* snapshot creation will dump an SQL file _containing drupal data only_ and include this in the snapshot image
  * The cloud instances will do the same when they do a backup/restore
* When restoring from a snapshot, the mysql database will be loaded from this dump
* Mysql users and permissions are not part of this dump, so are set via a separate process, using appropriate password values as defined in the dev environment's environment variables.

Snapshot restoration orchestration is the significant part:
1. mariadb needs to be started before Drupal (or any other services that depend on it)
2. For the purposes of the dev environment, mariadb needs to be queried in order to determine if it is empty (in which case, a restore is needed), or not (in which case, its state should be undisturbed).
3. Once mariadb is all set, then Drupal can be started

_For the cloud instances, this  orchestration is planned to happen externally to any of the IDC containers.  Therefore, this PR parallels this pattern, and runs the orchestration externally as well: in the Makefile._

Steps (1) and (2) of the orchestration turned out to be much messier than anticipated;  quirks in the mysql client and/or startup process mean that the the following situations need to be handled:
* the mysql client returns a non-zero error code as a result of a connection failure (this is straightforward, and expected)
* the mysql client returns a zero error code (success), but queries produce no results (INFORMATION_SCHEMA not populated yet?).  The net effect of this is that a `select count (*)` produces no value, not even `0`.  
* After successfully performing a successful query, subsequent queries may fail for any of the above reasons (i.e. you can get "connection failure", followed by "connection, but no result", followed by "connection, and successful query result", followed by "connection failure").  

As it stands right now in this PR, mutisites are not supported (i.e. it loads only the default Drupal db)

As of this PR, "new-style" snapshots are not compatible with "old-style".  Developers, when rebasing/merging this PR, would need to merge their work into this snapshot (i.e. start from this snapshot, then do `make config-import` to import their config work)

## To Test

* Checkout this PR, and do `make reset`.  This should work, and you should see the text like this text fly by: <pre>waiting for mysql to start...
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/run/mysqld/mysqld.sock' (2)
waiting for mysql to start...
No Drupal state found
make[1]: Entering directory '/home/birkland/projects/idc-isle-dc'
Creating mysql user drupal_default
Loading mysql dump
</pre>
* Now do `docker-compose stop` (to stop, but not destroy state), then `make up`.  Now, you should see different text: <pre>
Starting snapshot ... done
Starting idc_mariadb_1 ... done
waiting for mysql to start...
Pre-existing Drupal state found, not loading db from snapshot
</pre>
* If you were to do a `docker-compose down-v`, followed by `make up`, you should see it load from snapshot again.  
* Be creative and try other things.  load vs non-load should match your expectations.  For example, during `make test`, all test steps should be preceded by snapshot load, because each test suite starts from a clean slate.

Resolves jhu-idc/idc-general#259
