### PR TITLE
Access rights taxonomy migration

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-131-gc9ed1504.1611191329
+SNAPSHOT_TAG=upstream-20201007-739693ae-131-g2b45c5a3.1611258821
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_accessrights.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_accessrights.yml
@@ -1,0 +1,81 @@
+uuid: db283911-44a0-49a5-a0bb-1c15afc054fc
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_accessrights
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Access Rights'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+  constants:
+    STATUS: true
+    ADMIN: 1
+    DESC_FORMAT: basic_html
+process:
+  name: name
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  status: constants/STATUS
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: access_rights
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -10,6 +10,7 @@ fixture `Migration Tests`
   });
 
 const migrate_person_taxonomy = 'idc_ingest_taxonomy_persons';
+const migrate_accessrights_taxonomy = 'idc_ingest_taxonomy_accessrights';
 const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
@@ -38,6 +39,20 @@ test('Perform Person Taxonomy Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/persons-02.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Access Rights Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_accessrights_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/accessrights.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/accessrights.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/accessrights.csv
@@ -1,0 +1,2 @@
+local_id,name,authority,description
+accessrights_01,Public Domain,https://en.wikipedia.org/wiki/Public_domain_in_the_United_States;Wikipedia;local|https://creativecommons.org/publicdomain/zero/1.0/;CC-0;local,<p>Content is in the public domain.</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-accessrights.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-accessrights.json
@@ -1,0 +1,22 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "access_rights",
+  "name": "Public Domain",
+  "authority": [
+    {
+      "uri": "https://en.wikipedia.org/wiki/Public_domain_in_the_United_States",
+      "title": "Wikipedia",
+      "source": "local"
+    },
+    {
+      "uri": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "title": "CC-0",
+      "source": "local"
+    }
+  ],
+  "description": {
+    "value": "<p>Content is in the public domain.</p>",
+    "format": "basic_html",
+    "processed": "<p>Content is in the public domain.</p>"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -65,3 +65,20 @@ type ExpectedRepoObj struct {
 	DisplayHint string `json:"display_hint"`
 	Description string
 }
+
+// Represents the expected results of a migrated Access Rights taxonomy term
+type ExpectedAccessRights struct {
+	Type      string
+	Bundle    string
+	Name      string
+	Authority []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+}

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"net/url"
 	"strings"
 )
@@ -35,6 +37,20 @@ func (json *JsonApiUrl) String() string {
 
 	assert.Nil(json.t, err, "error generating a JsonAPI URL from %v: %s", json, err)
 	return u.String()
+}
+
+// Encapsulates a generic JSON API response
+type JsonApiResponse struct {
+	Data []map[string]interface{}
+}
+
+// Adapts the generic JsonApiResponse to a higher-fidelity type
+func (jar *JsonApiResponse) to(v interface{}) {
+	if b, e := json.Marshal(jar); e != nil {
+		log.Fatalf("Unable to marshal %v as json: %s", jar, e)
+	} else {
+		json.Unmarshal(b, v)
+	}
 }
 
 type JsonApiData struct {
@@ -81,6 +97,27 @@ type JsonApiPerson struct {
 				}
 			} `json:"field_relationships"`
 		} `json:"relationships"`
+	} `json:"data"`
+}
+
+// Represents the results of a JSONAPI query for a single Person from the Person Taxonomy
+type JsonApiAccessRights struct {
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
Adds an Access Rights Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/accessrights.csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-accessrights.json`

Will need to be rebased after #52 and #55 are merged.

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Access Rights Taxonomy.
4. Select the `Public Domain` taxonomy: this is the entry that was added by this PR (others are already seeded from the snapshot)
5. Observe that it has a name ("Public Domain"), a short description, and two authorities.