### PR TITLE
Add Copyright and Use taxonomy migration and test.

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-144-g5d7ff89.1611866437
+SNAPSHOT_TAG=upstream-20201007-739693ae-148-gc7d19160.1611931170
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_copyrightanduse.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_copyrightanduse.yml
@@ -1,0 +1,81 @@
+uuid: 24933acf-d899-4269-8182-7cfbfd2fc66a
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_copyrightanduse
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Copyright and Use'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+  constants:
+    STATUS: true
+    ADMIN: 1
+    DESC_FORMAT: basic_html
+process:
+  name: name
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  status: constants/STATUS
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: copyright_and_use
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -11,6 +11,7 @@ fixture `Migration Tests`
 
 const migrate_person_taxonomy = 'idc_ingest_taxonomy_persons';
 const migrate_accessrights_taxonomy = 'idc_ingest_taxonomy_accessrights';
+const migrate_copyrightanduse_taxonomy = 'idc_ingest_taxonomy_copyrightanduse';
 const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
@@ -53,6 +54,20 @@ test('Perform Access Rights Taxonomy Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/accessrights.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Copyright and Use Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_copyrightanduse_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/copyrightanduse.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/copyrightanduse.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/copyrightanduse.csv
@@ -1,0 +1,2 @@
+local_id,name,authority,description
+copyrightanduse_01,Unknowable Copyright Status,http://rightsstatements.org/vocab/UND/1.0/;Copyright Unknowable;rightsstatements,<p>The copyright status of the resource is unknowable.</p>

--- a/tests/10-migration-backend-tests/testcafe/migrations/copyrightanduse.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/copyrightanduse.csv
@@ -1,2 +1,2 @@
 local_id,name,authority,description
-copyrightanduse_01,Unknowable Copyright Status,http://rightsstatements.org/vocab/UND/1.0/;Copyright Unknowable;rightsstatements,<p>The copyright status of the resource is unknowable.</p>
+copyrightanduse_01,Unknowable Copyright Status,http://rightsstatements.org/vocab/UND/1.0/;Copyright Unknowable;rightsstatements|https://www.google.com;Google Knows All;other,<p>The copyright status of the resource is unknowable.</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-copyrightanduse.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-copyrightanduse.json
@@ -1,0 +1,17 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "copyright_and_use",
+  "name": "Unknowable Copyright Status",
+  "authority": [
+    {
+      "uri": "http://rightsstatements.org/vocab/UND/1.0/",
+      "title": "Copyright Unknowable",
+      "source": "rightsstatements"
+    }
+  ],
+  "description": {
+    "value": "<p>The copyright status of the resource is unknowable.</p>",
+    "format": "basic_html",
+    "processed": "<p>The copyright status of the resource is unknowable.</p>"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-copyrightanduse.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-copyrightanduse.json
@@ -7,6 +7,11 @@
       "uri": "http://rightsstatements.org/vocab/UND/1.0/",
       "title": "Copyright Unknowable",
       "source": "rightsstatements"
+    },
+    {
+      "uri": "https://www.google.com",
+      "title": "Google Knows All",
+      "source": "other"
     }
   ],
   "description": {

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -82,3 +82,20 @@ type ExpectedAccessRights struct {
 		Processed string
 	}
 }
+
+// Represents the expected results of a migrated Copyright and Use taxonomy term
+type ExpectedCopyrightAndUse struct {
+	Type      string
+	Bundle    string
+	Name      string
+	Authority []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+}

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -100,7 +100,7 @@ type JsonApiPerson struct {
 	} `json:"data"`
 }
 
-// Represents the results of a JSONAPI query for a single Person from the Person Taxonomy
+// Represents the results of a JSONAPI query for a single Access Rights Taxonomy Term
 type JsonApiAccessRights struct {
 	JsonApiData []struct {
 		Type              DrupalType
@@ -119,6 +119,27 @@ type JsonApiAccessRights struct {
 			} `json:"field_authority_link"`
 		} `json:"attributes"`
 	} `json:"data"`
+}
+
+// Represents the results of a JSONAPI query for a single Copyright and Use Taxonomy Term
+type JsonApiCopyrightAndUse struct {
+  JsonApiData []struct {
+    Type              DrupalType
+    Id                string
+    JsonApiAttributes struct {
+      Name        string
+      Description struct {
+        Value     string
+        Format    string
+        Processed string
+      }
+      Authority []struct {
+        Uri    string
+        Title  string
+        Source string
+      } `json:"field_authority_link"`
+    } `json:"attributes"`
+  } `json:"data"`
 }
 
 // Represents the results of a JSONAPI query for a single repository object

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -140,6 +140,45 @@ func Test_VerifyTaxonomyTermAccessRights(t *testing.T) {
 	}
 }
 
+func Test_VerifyTaxonomyCopyrightAndUse(t *testing.T) {
+  expectedJson := ExpectedCopyrightAndUse{}
+  unmarshalJson(t, "taxonomy-copyrightanduse.json", &expectedJson)
+
+  // sanity check the expected json
+  assert.Equal(t, "taxonomy_term", expectedJson.Type)
+  assert.Equal(t, "copyright_and_use", expectedJson.Bundle)
+
+  u := &JsonApiUrl{
+    t:            t,
+    baseUrl:      DrupalBaseurl,
+    drupalEntity: expectedJson.Type,
+    drupalBundle: expectedJson.Bundle,
+    filter:       "name",
+    value:        expectedJson.Name,
+  }
+
+  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+  res, body := getResource(t, u.String())
+  defer func() { _ = res.Close }()
+  copyrightRes := &JsonApiCopyrightAndUse{}
+  unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(copyrightRes)
+
+  actual := copyrightRes.JsonApiData[0]
+  assert.Equal(t, expectedJson.Type, actual.Type.entity())
+  assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+  assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+  assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+  assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+  assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+  assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+  assert.Equal(t, 1, len(actual.JsonApiAttributes.Authority))
+  for i, v := range actual.JsonApiAttributes.Authority {
+    assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+    assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+    assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+  }
+}
+
 func Test_VerifyCollection(t *testing.T) {
 
 }

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -141,42 +141,42 @@ func Test_VerifyTaxonomyTermAccessRights(t *testing.T) {
 }
 
 func Test_VerifyTaxonomyCopyrightAndUse(t *testing.T) {
-  expectedJson := ExpectedCopyrightAndUse{}
-  unmarshalJson(t, "taxonomy-copyrightanduse.json", &expectedJson)
+	expectedJson := ExpectedCopyrightAndUse{}
+	unmarshalJson(t, "taxonomy-copyrightanduse.json", &expectedJson)
 
-  // sanity check the expected json
-  assert.Equal(t, "taxonomy_term", expectedJson.Type)
-  assert.Equal(t, "copyright_and_use", expectedJson.Bundle)
+	// sanity check the expected json
+	assert.Equal(t, "taxonomy_term", expectedJson.Type)
+	assert.Equal(t, "copyright_and_use", expectedJson.Bundle)
 
-  u := &JsonApiUrl{
-    t:            t,
-    baseUrl:      DrupalBaseurl,
-    drupalEntity: expectedJson.Type,
-    drupalBundle: expectedJson.Bundle,
-    filter:       "name",
-    value:        expectedJson.Name,
-  }
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "name",
+		value:        expectedJson.Name,
+	}
 
-  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-  res, body := getResource(t, u.String())
-  defer func() { _ = res.Close }()
-  copyrightRes := &JsonApiCopyrightAndUse{}
-  unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(copyrightRes)
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	res, body := getResource(t, u.String())
+	defer func() { _ = res.Close }()
+	copyrightRes := &JsonApiCopyrightAndUse{}
+	unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(copyrightRes)
 
-  actual := copyrightRes.JsonApiData[0]
-  assert.Equal(t, expectedJson.Type, actual.Type.entity())
-  assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
-  assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
-  assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
-  assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
-  assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
-  assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
-  assert.Equal(t, 1, len(actual.JsonApiAttributes.Authority))
-  for i, v := range actual.JsonApiAttributes.Authority {
-    assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
-    assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
-    assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
-  }
+	actual := copyrightRes.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+	assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+	assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+	assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+	for i, v := range actual.JsonApiAttributes.Authority {
+		assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+		assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+		assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+	}
 }
 
 func Test_VerifyCollection(t *testing.T) {


### PR DESCRIPTION
Adds a Copyright and Use Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/copyrightanduse.csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-copyrightanduse.json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Copyright and Use Taxonomy.
4. Select the 'Unknowable Copyright Status' taxonomy term: this is the entry that was added by this PR
5. Observe that it has a name ("Unknowable Copyright Status"), a short description, and two authorities: one linking to rightsstatement.org, the other linking to Google.