### PR TITLE
Remove SOLR mounts

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ./codebase:/var/www/drupal:delegated
       - drupal-sites-data:/var/www/drupal/web/sites/default/files
-      - solr-data:/opt/solr/server/solr
+     #- solr-data:/opt/solr/server/solr
     depends_on:
       # Requires a the very minimum a database.
       - ${DRUPAL_DATABASE_SERVICE}

--- a/docker-compose.static.yml
+++ b/docker-compose.static.yml
@@ -26,7 +26,6 @@ services:
       DRUPAL_INSTANCE: static
     volumes:
       - drupal-sites-data:/var/www/drupal/web/sites/default/files
-      - solr-data:/opt/solr/server/solr
     depends_on:
       # Requires a the very minimum a database.
       - ${DRUPAL_DATABASE_SERVICE}


### PR DESCRIPTION
Removes SOLR mounts from static (cloud) _and_ local development environment.

As it stands now, the primary use case for this mount is the Initial environment bootstrapping (i.e. a Drupal init script creates the initial SOLR core).  As the cloud environments will not rely on Drupal bootstrapping SOLR, there is no need to expose the SOLR mount to Drupal.  This, this PR removes the mount from the static envornment.

However, over the course of researching the solr behaviour to determine if Drupal needed the mount for any other purpose, the [module documentation](https://git.drupalcode.org/project/search_api_solr#setting-up-solr-single-core) mentions:
> Note: Every time you add a new language to your Drupal instance or add a custom
Solr Field Type you have to update your core configuration files. Using the
example above they will be located in /var/solr/data/test-core/conf. The Drupal
admin UI should inform you about the requirement to update the  configuration.
Reload the core after updating the config using
curl -k http://localhost:8983/solr/admin/cores?action=RELOAD&core=$CORE on
the command line or enable the search_api_admin sub-module to do it from the
Drupal admin UI.
Note: There's file called solrcore.properties within the set of generated
config files. If you need to fine tune some setting you should do it within this
file if possible instead of modifying solrconf.xml.

The initial SOLR configuration is created by the ISLE install process.  To date, we have not encountered the kind of index change that would require new SOLR config.  If we ever did, we have no defined process for doing so in the development environment, nor do we have a defined process for updating the SOLR config in the cloud environment.  The likelihood of ever needing to do so is unclear.  To assure that we never encounter a situation where a developer accidentally updates the SOLR config in a snapshot SOLR instance and "calls it a day", this PR also removes the mount from the local/development environment.  Should we ever encounter the need to update SOLR config, we'd need to come up with a procedure for doing so.

Removing the mount obviously would affect `make bootstrap` target, which installs the stack from scratch (including creating a SOLR core).  At present, however, this target is broken.   If or when we address fixing the `make bootstrap` process, we can figure out how to initialize SOLR _without_ having to have SOLR mounted by the Drupal container at runtime after install.

# To test
Try poking at SOLR and make sure it still works as expected.  For example:
* change the fields indexed
* reindex all items

Resolves jhu-idc/idc-general#260