### PR TITLE
[DO NOT MERGE] Use env var for mariadb passwd in settings.php

### DIFF
--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-14-g09641e3
+TAG=upstream-20200824-f8d1e8e-20-gc483fdd
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-144-g5d7ff89.1611866437
@@ -78,4 +78,4 @@ IDP_BASEURL=https://islandora-idp.traefik.me:4443
 IDP_ENTITYID=https://islandora-idp.traefik.me/idp/shibboleth
 
 # DB params
-DRUPAL_DEFAULT_DB_PASSWORD=password
+DRUPAL_DEFAULT_DB_PASSWORD=moooooooo

--- a/codebase/web/sites/default/settings.php
+++ b/codebase/web/sites/default/settings.php
@@ -793,22 +793,10 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
 #   include $app_root . '/' . $site_path . '/settings.local.php';
 # }
 $settings['config_sync_directory'] = '/var/www/drupal/config/sync';
-$databases['default']['default'] = array (
-  'database' => 'drupal_default',
-  'username' => 'drupal_default',
-  'password' => 'password',
-  'prefix' => '',
-  'host' => 'mariadb-idc.traefik.me',
-  'port' => '3306',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-);
-$settings['flysystem']['fedora']['driver'] = 'fedora';
-$settings['flysystem']['fedora']['config']['root'] = 'http://fcrepo.isle-dc.localhost/fcrepo/rest/';
 $databases['default']['default']['database'] = 'drupal_default';
 $databases['default']['default']['username'] = 'drupal_default';
-$databases['default']['default']['password'] = 'password';
-$databases['default']['default']['host'] = 'mariadb-idc.traefik.me';
+$databases['default']['default']['password'] = getenv('DRUPAL_DEFAULT_DB_PASSWORD');
+$databases['default']['default']['host'] = getenv('DRUPAL_DEFAULT_DB_HOST');
 $databases['default']['default']['port'] = '3306';
 $databases['default']['default']['prefix'] = '';
 $databases['default']['default']['driver'] = 'mysql';


### PR DESCRIPTION
Points to an experimental set of images that expose environment
variables to Drupal, and sets the mariadb password in settings.php by
using getenv().

As an example, this sets an alternative mysql password, and allows Drupal to know about it by means of referencing the environment variable `DRUPAL_DEFAULT_DB_PASSWORD` within `settings.php`.

Previously, this was not possible.  The approach used by ISLE to set values in settings.php involved using custom `drush` commands to edit the file.  Unfortunately, this occurs only at installation time, and not startup time.  

This general approach of environment variable substitution would seem to be a fairly transparent and easy to understand.

Other approaches tried include 
* using templatizing settings.php and using confd to fill in values (I ultimately found this approach too cumbersome and abandoned it; see discussion in [a closed PR](https://github.com/jhu-idc/idc-isle-buildkit/pull/7)
* enhancing and building on the ISLE approach, and allow the settings.php file to be edited by drush upon startup, as shown in [a currently open PR](https://github.com/jhu-idc/idc-isle-buildkit/pull/24).
  * Noe:  In this PR, the settings.php file is edited _only_ in the production/cloud environment, not the development environment.  I think we'd need to come up with a way for it to behave similarly in the development environment if we took this route.
