### PR TITLE
Family taxonomy migration

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-178-g1ae8f04.1612376594
+SNAPSHOT_TAG=upstream-20201007-739693ae-154-g443f9ff5.1612457793
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_family.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_family.yml
@@ -1,0 +1,108 @@
+uuid: 70038cdf-4c0e-4134-896d-764c7dbd4fbc
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_family
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Family'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+process:
+  name: name
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  field_family_name: family_name
+  field_title_and_other_words: title_and_other_words
+  field_date:
+    -
+      plugin: explode
+      source: date
+      delimiter: '|'
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          - plugin: skip_on_empty
+            method: process
+            source: value
+          - plugin: explode
+            source: value
+            delimiter: ;
+          - plugin: extract
+            index:
+              - 0
+        title:
+          - plugin: skip_on_empty
+            method: process
+            source: value
+          - plugin: explode
+            source: value
+            delimiter: ;
+          - plugin: extract
+            index:
+              - 1
+        source:
+          - plugin: skip_on_empty
+            method: process
+            source: value
+          - plugin: explode
+            source: value
+            delimiter: ;
+          - plugin: extract
+            index:
+              - 2
+  field_relationships:
+    -
+      plugin: explode
+      source: relationships
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+      keyname: relationships
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: explode
+            source: relationships
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+          -
+            plugin: migration_lookup
+            migration: idc_ingest_taxonomy_family
+            no_stub: true
+        rel_type:
+          -
+            plugin: explode
+            source: relationships
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: family
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -12,6 +12,7 @@ fixture `Migration Tests`
 const migrate_person_taxonomy = 'idc_ingest_taxonomy_persons';
 const migrate_accessrights_taxonomy = 'idc_ingest_taxonomy_accessrights';
 const migrate_copyrightanduse_taxonomy = 'idc_ingest_taxonomy_copyrightanduse';
+const migrate_family_taxonomy = 'idc_ingest_taxonomy_family';
 const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
@@ -40,6 +41,31 @@ test('Perform Person Taxonomy Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/persons-02.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Family Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_family_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/family-01.csv'
+    ])
+    .click('#edit-import');
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_family_taxonomy))
+    .expect(selectUpdateExistingRecords.checked).ok();  // n.b. checked by default
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/family-02.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/family-01.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/family-01.csv
@@ -1,0 +1,3 @@
+local_id,name,family_name,title_and_other_words,date,authority,relationships,description
+family-01,Hatfields,Hatfield,Hatfield Title,1863|1891,https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud;Wikipedia;other|http://www.google.com;Google Alt Link;other,,<p>Hatfield description</p>
+family-02,McCoy,McCoy,McCoy Title,1863|1891,https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud;Wikipedia;other|http://www.google.com;Google Alt Link;other,,<p>McCoy description</p>

--- a/tests/10-migration-backend-tests/testcafe/migrations/family-02.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/family-02.csv
@@ -1,0 +1,3 @@
+local_id,name,family_name,title_and_other_words,date,authority,relationships,description
+family-01,Hatfields,Hatfield,Hatfield Title,1863|1891,https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud;Wikipedia;other|http://www.google.com;Google Alt Link;other,family-02;schema:knowsAbout,<p>Hatfield description</p>
+family-02,McCoy,McCoy,McCoy Title,1863|1891,https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud;Wikipedia;other|http://www.google.com;Google Alt Link;other,family-01;schema:knowsAbout,<p>McCoy description</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-family-01.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-family-01.json
@@ -1,0 +1,31 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "family",
+  "name": "Hatfields",
+  "description": {
+    "value": "<p>Hatfield description</p>",
+    "format": "basic_html",
+    "processed": "<p>Hatfield description</p>"
+  },
+  "authority": [
+    {
+      "uri": "https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud",
+      "title": "Wikipedia",
+      "source": "other"
+    },
+    {
+      "uri": "http://www.google.com",
+      "title": "Google Alt Link",
+      "source": "other"
+    }
+  ],
+  "date": [
+    "1863",
+    "1891"
+  ],
+  "family_name": "Hatfield",
+  "title_and_other_words": "Hatfield Title",
+  "knowsAbout": [
+    "McCoy"
+  ]
+}

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-family-02.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-family-02.json
@@ -1,0 +1,31 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "family",
+  "name": "McCoy",
+  "description": {
+    "value": "<p>McCoy description</p>",
+    "format": "basic_html",
+    "processed": "<p>McCoy description</p>"
+  },
+  "authority": [
+    {
+      "uri": "https://en.wikipedia.org/wiki/Hatfield%E2%80%93McCoy_feud",
+      "title": "Wikipedia",
+      "source": "other"
+    },
+    {
+      "uri": "http://www.google.com",
+      "title": "Google Alt Link",
+      "source": "other"
+    }
+  ],
+  "date": [
+    "1863",
+    "1891"
+  ],
+  "family_name": "McCoy",
+  "title_and_other_words": "McCoy Title",
+  "knowsAbout": [
+    "Hatfields"
+  ]
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -99,3 +99,24 @@ type ExpectedCopyrightAndUse struct {
 		Processed string
 	}
 }
+
+// Represents the expected results of a migrated Family taxonomy term
+type ExpectedFamily struct {
+  Type      string
+  Bundle    string
+  Name      string
+  Date      []string
+  FamilyName string `json:"family_name"`
+  Title string
+  Authority []struct {
+    Uri    string
+    Title  string
+    Source string
+  }
+  Description struct {
+    Value     string
+    Format    string
+    Processed string
+  }
+  KnowsAbout []string `json:"knowsAbout"`
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -102,21 +102,21 @@ type ExpectedCopyrightAndUse struct {
 
 // Represents the expected results of a migrated Family taxonomy term
 type ExpectedFamily struct {
-  Type      string
-  Bundle    string
-  Name      string
-  Date      []string
-  FamilyName string `json:"family_name"`
-  Title string
-  Authority []struct {
-    Uri    string
-    Title  string
-    Source string
-  }
-  Description struct {
-    Value     string
-    Format    string
-    Processed string
-  }
-  KnowsAbout []string `json:"knowsAbout"`
+	Type       string
+	Bundle     string
+	Name       string
+	Date       []string
+	FamilyName string `json:"family_name"`
+	Title      string
+	Authority  []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+	KnowsAbout []string `json:"knowsAbout"`
 }

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-  "encoding/json"
-  "fmt"
-  "github.com/stretchr/testify/assert"
-  "log"
-  "net/url"
-  "strings"
-  "testing"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"net/url"
+	"strings"
+	"testing"
 )
 
 // Encapsulates the relevant components of a URL which executes a JSON API request against Drupal
@@ -41,12 +41,11 @@ func (json *JsonApiUrl) String() string {
 }
 
 func (jar *JsonApiUrl) get(v interface{}) {
-  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-  res, body := getResource(jar.t.(*testing.T), jar.String())
-  defer func() { _ = res.Close }()
-  unmarshalSingleResponse(jar.t.(*testing.T), body, res, &JsonApiResponse{}).to(v)
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	res, body := getResource(jar.t.(*testing.T), jar.String())
+	defer func() { _ = res.Close }()
+	unmarshalSingleResponse(jar.t.(*testing.T), body, res, &JsonApiResponse{}).to(v)
 }
-
 
 // Encapsulates a generic JSON API response
 type JsonApiResponse struct {
@@ -132,55 +131,55 @@ type JsonApiAccessRights struct {
 
 // Represents the results of a JSONAPI query for a single Copyright and Use Taxonomy Term
 type JsonApiCopyrightAndUse struct {
-  JsonApiData []struct {
-    Type              DrupalType
-    Id                string
-    JsonApiAttributes struct {
-      Name        string
-      Description struct {
-        Value     string
-        Format    string
-        Processed string
-      }
-      Authority []struct {
-        Uri    string
-        Title  string
-        Source string
-      } `json:"field_authority_link"`
-    } `json:"attributes"`
-  } `json:"data"`
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
+	} `json:"data"`
 }
 
 // Represents the results of a JSONAPI query for a single Family Taxonomy Term
 type JsonApiFamily struct {
-  JsonApiData []struct {
-    Type              DrupalType
-    Id                string
-    JsonApiAttributes struct {
-      Name        string
-      Date []string `json:"field_date"`
-      FamilyName string `json:"field_family_name"`
-      Title string `json:"field_title_and_other_words"`
-      Description struct {
-        Value     string
-        Format    string
-        Processed string
-      }
-      Authority []struct {
-        Uri    string
-        Title  string
-        Source string
-      } `json:"field_authority_link"`
-    } `json:"attributes"`
-    JsonApiRelationships struct {
-      Relationships struct {
-        Data []struct {
-          JsonApiData
-          Meta map[string]string
-        }
-      } `json:"field_relationships"`
-    } `json:"relationships"`
-  } `json:"data"`
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Date        []string `json:"field_date"`
+			FamilyName  string   `json:"field_family_name"`
+			Title       string   `json:"field_title_and_other_words"`
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
+		JsonApiRelationships struct {
+			Relationships struct {
+				Data []struct {
+					JsonApiData
+					Meta map[string]string
+				}
+			} `json:"field_relationships"`
+		} `json:"relationships"`
+	} `json:"data"`
 }
 
 // Represents the results of a JSONAPI query for a single repository object

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/stretchr/testify/assert"
-	"log"
-	"net/url"
-	"strings"
+  "encoding/json"
+  "fmt"
+  "github.com/stretchr/testify/assert"
+  "log"
+  "net/url"
+  "strings"
+  "testing"
 )
 
 // Encapsulates the relevant components of a URL which executes a JSON API request against Drupal
@@ -38,6 +39,14 @@ func (json *JsonApiUrl) String() string {
 	assert.Nil(json.t, err, "error generating a JsonAPI URL from %v: %s", json, err)
 	return u.String()
 }
+
+func (jar *JsonApiUrl) get(v interface{}) {
+  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+  res, body := getResource(jar.t.(*testing.T), jar.String())
+  defer func() { _ = res.Close }()
+  unmarshalSingleResponse(jar.t.(*testing.T), body, res, &JsonApiResponse{}).to(v)
+}
+
 
 // Encapsulates a generic JSON API response
 type JsonApiResponse struct {
@@ -139,6 +148,38 @@ type JsonApiCopyrightAndUse struct {
         Source string
       } `json:"field_authority_link"`
     } `json:"attributes"`
+  } `json:"data"`
+}
+
+// Represents the results of a JSONAPI query for a single Family Taxonomy Term
+type JsonApiFamily struct {
+  JsonApiData []struct {
+    Type              DrupalType
+    Id                string
+    JsonApiAttributes struct {
+      Name        string
+      Date []string `json:"field_date"`
+      FamilyName string `json:"field_family_name"`
+      Title string `json:"field_title_and_other_words"`
+      Description struct {
+        Value     string
+        Format    string
+        Processed string
+      }
+      Authority []struct {
+        Uri    string
+        Title  string
+        Source string
+      } `json:"field_authority_link"`
+    } `json:"attributes"`
+    JsonApiRelationships struct {
+      Relationships struct {
+        Data []struct {
+          JsonApiData
+          Meta map[string]string
+        }
+      } `json:"field_relationships"`
+    } `json:"relationships"`
   } `json:"data"`
 }
 

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -174,69 +174,69 @@ func Test_VerifyTaxonomyCopyrightAndUse(t *testing.T) {
 }
 
 func Test_VerifyTaxonomyTermFamily(t *testing.T) {
-  expectedJson := ExpectedFamily{}
-  unmarshalJson(t, "taxonomy-family-01.json", &expectedJson)
+	expectedJson := ExpectedFamily{}
+	unmarshalJson(t, "taxonomy-family-01.json", &expectedJson)
 
-  // sanity check the expected json
-  assert.Equal(t, "taxonomy_term", expectedJson.Type)
-  assert.Equal(t, "family", expectedJson.Bundle)
+	// sanity check the expected json
+	assert.Equal(t, "taxonomy_term", expectedJson.Type)
+	assert.Equal(t, "family", expectedJson.Bundle)
 
-  u := &JsonApiUrl{
-    t:            t,
-    baseUrl:      DrupalBaseurl,
-    drupalEntity: expectedJson.Type,
-    drupalBundle: expectedJson.Bundle,
-    filter:       "name",
-    value:        expectedJson.Name,
-  }
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "name",
+		value:        expectedJson.Name,
+	}
 
-  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-  familyres := &JsonApiFamily{}
-  u.get(familyres)
-  sourceId := familyres.JsonApiData[0].Id
-  assert.NotEmpty(t, sourceId)
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	familyres := &JsonApiFamily{}
+	u.get(familyres)
+	sourceId := familyres.JsonApiData[0].Id
+	assert.NotEmpty(t, sourceId)
 
-  actual := familyres.JsonApiData[0]
-  assert.Equal(t, expectedJson.Type, actual.Type.entity())
-  assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
-  assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
-  assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
-  assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
-  assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
-  assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
-  assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
-  for i, v := range actual.JsonApiAttributes.Authority {
-    assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
-    assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
-    assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
-  }
-  assert.Equal(t, expectedJson.Title, actual.JsonApiAttributes.Title)
-  assert.Equal(t, expectedJson.FamilyName, actual.JsonApiAttributes.FamilyName)
-  assert.Equal(t, 2, len(actual.JsonApiAttributes.Date))
-  assert.Equal(t, 2, len(expectedJson.Date))
-  for i, v := range actual.JsonApiAttributes.Date {
-    assert.Equal(t, expectedJson.Date[i], v)
-  }
+	actual := familyres.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+	assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+	assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+	assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+	for i, v := range actual.JsonApiAttributes.Authority {
+		assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+		assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+		assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+	}
+	assert.Equal(t, expectedJson.Title, actual.JsonApiAttributes.Title)
+	assert.Equal(t, expectedJson.FamilyName, actual.JsonApiAttributes.FamilyName)
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Date))
+	assert.Equal(t, 2, len(expectedJson.Date))
+	for i, v := range actual.JsonApiAttributes.Date {
+		assert.Equal(t, expectedJson.Date[i], v)
+	}
 
-  // Resolve relationship to a name
-  relData := familyres.JsonApiData[0].JsonApiRelationships.Relationships.Data[0]
-  assert.Equal(t, "schema:knowsAbout", relData.Meta["rel_type"])
-  u.value = expectedJson.KnowsAbout[0]
+	// Resolve relationship to a name
+	relData := familyres.JsonApiData[0].JsonApiRelationships.Relationships.Data[0]
+	assert.Equal(t, "schema:knowsAbout", relData.Meta["rel_type"])
+	u.value = expectedJson.KnowsAbout[0]
 
-  // retrieve json of the resolved entity from the jsonapi
-  familyres = &JsonApiFamily{}
-  u.get(familyres)
-  relSchemaKnowsAbout := familyres.JsonApiData[0]
+	// retrieve json of the resolved entity from the jsonapi
+	familyres = &JsonApiFamily{}
+	u.get(familyres)
+	relSchemaKnowsAbout := familyres.JsonApiData[0]
 
-  // sanity
-  assert.Equal(t, relSchemaKnowsAbout.Type.bundle(), "family")
-  assert.Equal(t, relSchemaKnowsAbout.Type.entity(), "taxonomy_term")
+	// sanity
+	assert.Equal(t, relSchemaKnowsAbout.Type.bundle(), "family")
+	assert.Equal(t, relSchemaKnowsAbout.Type.entity(), "taxonomy_term")
 
-  // test
-  assert.Equal(t, expectedJson.KnowsAbout[0], relSchemaKnowsAbout.JsonApiAttributes.Name)
+	// test
+	assert.Equal(t, expectedJson.KnowsAbout[0], relSchemaKnowsAbout.JsonApiAttributes.Name)
 
-  // assert the reciprocal relationship holds (e.g. the id referenced by the target is the same as the source id)
-  assert.Equal(t, sourceId, relSchemaKnowsAbout.JsonApiRelationships.Relationships.Data[0].Id)
+	// assert the reciprocal relationship holds (e.g. the id referenced by the target is the same as the source id)
+	assert.Equal(t, sourceId, relSchemaKnowsAbout.JsonApiRelationships.Relationships.Data[0].Id)
 }
 
 func Test_VerifyCollection(t *testing.T) {

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -47,10 +47,8 @@ func Test_VerifyTaxonomyTermPerson(t *testing.T) {
 	}
 
 	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-	res, body := getResource(t, u.String())
-	defer func() { _ = res.Close }()
 	personRes := &JsonApiPerson{}
-	unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(personRes)
+	u.get(personRes)
 
 	// for each field in expected json,
 	//   see if the expected field matches the actual field from retrieved json
@@ -87,10 +85,8 @@ func Test_VerifyTaxonomyTermPerson(t *testing.T) {
 	u.value = expectedJson.Knows[0]
 
 	// retrieve json of the resolved entity from the jsonapi
-	res, body = getResource(t, u.String())
-	defer func() { _ = res.Close }()
 	personRes = &JsonApiPerson{}
-	unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(personRes)
+	u.get(personRes)
 	relSchemaKnows := personRes.JsonApiData[0]
 
 	// sanity
@@ -119,10 +115,8 @@ func Test_VerifyTaxonomyTermAccessRights(t *testing.T) {
 	}
 
 	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-	res, body := getResource(t, u.String())
-	defer func() { _ = res.Close }()
 	accessRightsRes := &JsonApiAccessRights{}
-	unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(accessRightsRes)
+	u.get(accessRightsRes)
 
 	actual := accessRightsRes.JsonApiData[0]
 	assert.Equal(t, expectedJson.Type, actual.Type.entity())

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -179,6 +179,72 @@ func Test_VerifyTaxonomyCopyrightAndUse(t *testing.T) {
 	}
 }
 
+func Test_VerifyTaxonomyTermFamily(t *testing.T) {
+  expectedJson := ExpectedFamily{}
+  unmarshalJson(t, "taxonomy-family-01.json", &expectedJson)
+
+  // sanity check the expected json
+  assert.Equal(t, "taxonomy_term", expectedJson.Type)
+  assert.Equal(t, "family", expectedJson.Bundle)
+
+  u := &JsonApiUrl{
+    t:            t,
+    baseUrl:      DrupalBaseurl,
+    drupalEntity: expectedJson.Type,
+    drupalBundle: expectedJson.Bundle,
+    filter:       "name",
+    value:        expectedJson.Name,
+  }
+
+  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+  familyres := &JsonApiFamily{}
+  u.get(familyres)
+  sourceId := familyres.JsonApiData[0].Id
+  assert.NotEmpty(t, sourceId)
+
+  actual := familyres.JsonApiData[0]
+  assert.Equal(t, expectedJson.Type, actual.Type.entity())
+  assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+  assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+  assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+  assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+  assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+  assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+  assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+  for i, v := range actual.JsonApiAttributes.Authority {
+    assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+    assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+    assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+  }
+  assert.Equal(t, expectedJson.Title, actual.JsonApiAttributes.Title)
+  assert.Equal(t, expectedJson.FamilyName, actual.JsonApiAttributes.FamilyName)
+  assert.Equal(t, 2, len(actual.JsonApiAttributes.Date))
+  assert.Equal(t, 2, len(expectedJson.Date))
+  for i, v := range actual.JsonApiAttributes.Date {
+    assert.Equal(t, expectedJson.Date[i], v)
+  }
+
+  // Resolve relationship to a name
+  relData := familyres.JsonApiData[0].JsonApiRelationships.Relationships.Data[0]
+  assert.Equal(t, "schema:knowsAbout", relData.Meta["rel_type"])
+  u.value = expectedJson.KnowsAbout[0]
+
+  // retrieve json of the resolved entity from the jsonapi
+  familyres = &JsonApiFamily{}
+  u.get(familyres)
+  relSchemaKnowsAbout := familyres.JsonApiData[0]
+
+  // sanity
+  assert.Equal(t, relSchemaKnowsAbout.Type.bundle(), "family")
+  assert.Equal(t, relSchemaKnowsAbout.Type.entity(), "taxonomy_term")
+
+  // test
+  assert.Equal(t, expectedJson.KnowsAbout[0], relSchemaKnowsAbout.JsonApiAttributes.Name)
+
+  // assert the reciprocal relationship holds (e.g. the id referenced by the target is the same as the source id)
+  assert.Equal(t, sourceId, relSchemaKnowsAbout.JsonApiRelationships.Relationships.Data[0].Id)
+}
+
 func Test_VerifyCollection(t *testing.T) {
 
 }


### PR DESCRIPTION
Adds a Family Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/family-0[12].csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-family-0[12].json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Family Taxonomy.
4. Observe two families, `Hatfields` and `McCoy`; these terms are added by the test included in this PR
5. Select the `Hatfields`
6. Observe that it has two authorities, two dates, and a `Knows about` relationship with `McCoy`
7. Click on `McCoy`.  Observe that the term has a `Knows about` relationship with `Hatfields` 