### PR TITLE
Genre taxonomy migration

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-158-g17062e4b.1612467847
+SNAPSHOT_TAG=upstream-20201007-739693ae-165-g0b8fa689.1612896672
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-154-g443f9ff5.1612457793
+SNAPSHOT_TAG=upstream-20201007-739693ae-158-g17062e4b.1612467847
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_genre.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_genre.yml
@@ -1,0 +1,81 @@
+uuid: 09329c16-94ef-472f-a6ae-08467f607426
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_genre
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Genre/Form'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+  constants:
+    STATUS: true
+    ADMIN: 1
+    DESC_FORMAT: basic_html
+process:
+  name: name
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  status: constants/STATUS
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: genre
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -13,6 +13,7 @@ const migrate_person_taxonomy = 'idc_ingest_taxonomy_persons';
 const migrate_accessrights_taxonomy = 'idc_ingest_taxonomy_accessrights';
 const migrate_copyrightanduse_taxonomy = 'idc_ingest_taxonomy_copyrightanduse';
 const migrate_family_taxonomy = 'idc_ingest_taxonomy_family';
+const migrate_genre_taxonomy = 'idc_ingest_taxonomy_genre';
 const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
@@ -108,6 +109,20 @@ test('Perform Collection Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/collection.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Genre Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_genre_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/genre.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/genre.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/genre.csv
@@ -1,0 +1,2 @@
+local_id,name,authority,description
+genre-01,Drama,https://www.loc.gov/aba/publications/FreeLCGFT/GENRE.pdf;Action/Adventure;lgcft|http://www.google.com;Google Alt Link;other,<p>Drama Description</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-genre.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-genre.json
@@ -1,0 +1,22 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "genre",
+  "name": "Drama",
+  "authority": [
+    {
+      "uri": "https://www.loc.gov/aba/publications/FreeLCGFT/GENRE.pdf",
+      "title": "Action/Adventure",
+      "source": "lgcft"
+    },
+    {
+      "uri": "http://www.google.com",
+      "title": "Google Alt Link",
+      "source": "other"
+    }
+  ],
+  "description": {
+    "value": "<p>Drama Description</p>",
+    "format": "basic_html",
+    "processed": "<p>Drama Description</p>"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -120,3 +120,20 @@ type ExpectedFamily struct {
 	}
 	KnowsAbout []string `json:"knowsAbout"`
 }
+
+// Represents the expected results of a migrated Genre taxonomy term
+type ExpectedGenre struct {
+	Type      string
+	Bundle    string
+	Name      string
+	Authority []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+}

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -214,3 +214,24 @@ type JsonApiRepoObj struct {
 		} `json:"relationships"`
 	} `json:"data"`
 }
+
+// Represents the results of a JSONAPI query for a single Genre Term
+type JsonApiGenre struct {
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -152,10 +152,8 @@ func Test_VerifyTaxonomyCopyrightAndUse(t *testing.T) {
 	}
 
 	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-	res, body := getResource(t, u.String())
-	defer func() { _ = res.Close }()
 	copyrightRes := &JsonApiCopyrightAndUse{}
-	unmarshalSingleResponse(t, body, res, &JsonApiResponse{}).to(copyrightRes)
+	u.get(copyrightRes)
 
 	actual := copyrightRes.JsonApiData[0]
 	assert.Equal(t, expectedJson.Type, actual.Type.entity())

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -237,6 +237,43 @@ func Test_VerifyTaxonomyTermFamily(t *testing.T) {
 	assert.Equal(t, sourceId, relSchemaKnowsAbout.JsonApiRelationships.Relationships.Data[0].Id)
 }
 
+func Test_VerifyTaxonomyTermGenre(t *testing.T) {
+	expectedJson := ExpectedGenre{}
+	unmarshalJson(t, "taxonomy-genre.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, "taxonomy_term", expectedJson.Type)
+	assert.Equal(t, "genre", expectedJson.Bundle)
+
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "name",
+		value:        expectedJson.Name,
+	}
+
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	genreRes := &JsonApiGenre{}
+	u.get(genreRes)
+
+	actual := genreRes.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+	assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+	assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+	assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+	for i, v := range actual.JsonApiAttributes.Authority {
+		assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+		assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+		assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+	}
+}
+
 func Test_VerifyCollection(t *testing.T) {
 
 }


### PR DESCRIPTION
Adds a Genre Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/genre.csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-genre.json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Genre Taxonomy.
4. Observe one entry, 'Drama'; this term is added by the test included in this PR
5. Select `Drama`
6. Observe that it has two authorities and a description.

~~N.B. Includes changes introduced by #64, will need to be rebased after #64 is merged.~~