### PR TITLE
Add migration and test for Resource Types taxonomy.

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-172-g912efc8d.1612898846
+SNAPSHOT_TAG=upstream-20201007-739693ae-175-gb6b8b550.1612900403
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_resourcetypes.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_resourcetypes.yml
@@ -1,0 +1,81 @@
+uuid: e988cc68-c76d-4ced-b7ee-5a0d1e412217
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_resourcetypes
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Resource Types'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+  constants:
+    STATUS: true
+    ADMIN: 1
+    DESC_FORMAT: basic_html
+process:
+  name: name
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  status: constants/STATUS
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: resource_types
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -18,6 +18,7 @@ const migrate_geolocation_taxonomy = 'idc_ingest_taxonomy_geolocation';
 const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
+const migrate_resource_types = 'idc_ingest_taxonomy_resourcetypes';
 
 const selectMigration = Selector('#edit-migrations');
 const migrationOptions = selectMigration.find('option');
@@ -110,6 +111,20 @@ test('Perform Geolocation Taxonomy Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/geolocation.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Resource Types Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_resource_types));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/resourcetypes.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/resourcetypes.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/resourcetypes.csv
@@ -1,0 +1,2 @@
+local_id,name,authority,description
+resourcetype_01,My Still Image,https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dcmitype/StillImage/;Still Image;dcmi_types|http://www.google.com;Another Authority;dcmi_types,<p>My still image description.</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-resourcetypes.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-resourcetypes.json
@@ -1,0 +1,22 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "resource_types",
+  "name": "My Still Image",
+  "authority": [
+    {
+      "uri": "https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dcmitype/StillImage/",
+      "title": "Still Image",
+      "source": "dcmi_types"
+    },
+    {
+      "uri": "http://www.google.com",
+      "title": "Another Authority",
+      "source": "dcmi_types"
+    }
+  ],
+  "description": {
+    "value": "<p>My still image description.</p>",
+    "format": "basic_html",
+    "processed": "<p>My still image description.</p>"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -161,3 +161,20 @@ type ExpectedGeolocation struct {
 		Processed string
 	}
 }
+
+// Represents the expected results of a migrated Resource Types taxonomy term
+type ExpectedResourceType struct {
+	Type      string
+	Bundle    string
+	Name      string
+	Authority []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+}

--- a/tests/10-migration-backend-tests/verification/go.sum
+++ b/tests/10-migration-backend-tests/verification/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -261,3 +261,24 @@ type JsonApiGeolocation struct {
 		} `json:"attributes"`
 	} `json:"data"`
 }
+
+// Represents the results of a JSONAPI query for a single Resource Types Taxonomy Term
+type JsonApiResourceType struct {
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -320,6 +320,43 @@ func Test_VerifyTaxonomyTermGeolocation(t *testing.T) {
 	}
 }
 
+func Test_VerifyTaxonomyTermResourceType(t *testing.T) {
+	expectedJson := ExpectedAccessRights{}
+	unmarshalJson(t, "taxonomy-resourcetypes.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, "taxonomy_term", expectedJson.Type)
+	assert.Equal(t, "resource_types", expectedJson.Bundle)
+
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "name",
+		value:        expectedJson.Name,
+	}
+
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	res := &JsonApiResourceType{}
+	u.get(res)
+
+	actual := res.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+	assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+	assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+	assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+	for i, v := range actual.JsonApiAttributes.Authority {
+		assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+		assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+		assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+	}
+}
+
 func Test_VerifyCollection(t *testing.T) {
 
 }


### PR DESCRIPTION
Adds a Resource Types Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/resourcetypes.csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-resourcetypes.json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Resource Types Taxonomy.
4. Observe the entry, 'My Still Image'; this term is added by the test included in this PR
5. Select `My Still Image`
6. Observe that it has two authorities and a description.