### PR TITLE
Add migration and test for Subject taxonomy.

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-175-gb6b8b550.1612900403
+SNAPSHOT_TAG=upstream-20201007-739693ae-178-gff1510be.1612901956
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_subject.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_subject.yml
@@ -1,0 +1,81 @@
+uuid: c74010f3-f276-4bfd-a5f4-1be7ac667161
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_subject
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Subjects'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+  constants:
+    STATUS: true
+    ADMIN: 1
+    DESC_FORMAT: basic_html
+process:
+  name: name
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  status: constants/STATUS
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: subject
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -19,6 +19,7 @@ const migrate_new_items = 'idc_ingest_new_items';
 const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
 const migrate_resource_types = 'idc_ingest_taxonomy_resourcetypes';
+const migrate_subject_taxonomy = 'idc_ingest_taxonomy_subject';
 
 const selectMigration = Selector('#edit-migrations');
 const migrationOptions = selectMigration.find('option');
@@ -97,6 +98,20 @@ test('Perform Copyright and Use Taxonomy Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/copyrightanduse.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Subject Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_subject_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/subject.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/subject.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/subject.csv
@@ -1,0 +1,2 @@
+local_id,name,authority,description
+subject-01,Analog Photography,http://www.google.com?q=Analog%20Photography;Google;other|http://www.ford.com;Nothing to do with Analog Photography But Works For a Test;iso19115,<p>Analog photography description.</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-subject.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-subject.json
@@ -1,0 +1,22 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "subject",
+  "name": "Analog Photography",
+  "authority": [
+    {
+      "uri": "http://www.google.com?q=Analog%20Photography",
+      "title": "Google",
+      "source": "other"
+    },
+    {
+      "uri": "http://www.ford.com",
+      "title": "Nothing to do with Analog Photography But Works For a Test",
+      "source": "iso19115"
+    }
+  ],
+  "description": {
+    "value": "<p>Analog photography description.</p>",
+    "format": "basic_html",
+    "processed": "<p>Analog photography description.</p>"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -178,3 +178,20 @@ type ExpectedResourceType struct {
 		Processed string
 	}
 }
+
+// Represents the expected results of a migrated Subject taxonomy term
+type ExpectedSubject struct {
+	Type      string
+	Bundle    string
+	Name      string
+	Authority []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+}

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -282,3 +282,24 @@ type JsonApiResourceType struct {
 		} `json:"attributes"`
 	} `json:"data"`
 }
+
+// Represents the results of a JSONAPI query for a single Subject Term
+type JsonApiSubject struct {
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -357,6 +357,43 @@ func Test_VerifyTaxonomyTermResourceType(t *testing.T) {
 	}
 }
 
+func Test_VerifyTaxonomySubject(t *testing.T) {
+	expectedJson := ExpectedSubject{}
+	unmarshalJson(t, "taxonomy-subject.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, "taxonomy_term", expectedJson.Type)
+	assert.Equal(t, "subject", expectedJson.Bundle)
+
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "name",
+		value:        expectedJson.Name,
+	}
+
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	res := &JsonApiSubject{}
+	u.get(res)
+
+	actual := res.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Name, actual.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Description.Format, actual.JsonApiAttributes.Description.Format)
+	assert.Equal(t, expectedJson.Description.Value, actual.JsonApiAttributes.Description.Value)
+	assert.Equal(t, expectedJson.Description.Processed, actual.JsonApiAttributes.Description.Processed)
+	assert.Equal(t, len(expectedJson.Authority), len(actual.JsonApiAttributes.Authority))
+	assert.Equal(t, 2, len(actual.JsonApiAttributes.Authority))
+	for i, v := range actual.JsonApiAttributes.Authority {
+		assert.Equal(t, expectedJson.Authority[i].Title, v.Title)
+		assert.Equal(t, expectedJson.Authority[i].Source, v.Source)
+		assert.Equal(t, expectedJson.Authority[i].Uri, v.Uri)
+	}
+}
+
 func Test_VerifyCollection(t *testing.T) {
 
 }


### PR DESCRIPTION
Adds a Subject Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/subject.csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-subject.json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Subject Taxonomy.
4. Observe the entry, 'Analog Photography'; this term is added by the test included in this PR
5. Select `Analog Photography`
6. Observe that it has two authorities and a description.