### PR TITLE
Collection object migration

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-181-g4ace3d4a.1612987314
+SNAPSHOT_TAG=upstream-20201007-739693ae-189-g38e75a4c.1613008207
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_new_collection.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_new_collection.yml
@@ -14,19 +14,144 @@ source:
   ids:
     - local_id
   path: 'Will be populated by the Migrate Source UI'
-  constants:
-    COLLECTION_MODEL_NAME: Collection
 process:
-  title: name
-  field_description: description
-  field_model:
+  title: title
+  field_collection_contact_email: contact_email
+  field_collection_contact_name: contact_name
+  field_collection_number:
+    plugin: explode
+    source: collection_number
+    delimiter: '|'
+    strict: false
+  field_finding_aid:
+    -
+      plugin: explode
+      source: finding_aid
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 1
+  field_description:
+    -
+      plugin: explode
+      source: description
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        value:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 0
+        target_id:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 1
+          -
+            plugin: entity_lookup
+            entity_type: taxonomy_term
+            bundle: language
+            bundle_key: vid
+            value_key: field_language_code
+  field_member_of:
+    plugin: migration_lookup
+    migration: idc_ingest_new_collection
+    source: member_of
+  field_title_language:
     plugin: entity_lookup
-    bundle_key: vid
-    bundle: islandora_models
+    source: title_language
     entity_type: taxonomy_term
-    value_key: name
-    source: constants/COLLECTION_MODEL_NAME
+    bundle: language
+    bundle_key: vid
+    value_key: field_language_code
+  field_alternative_title:
+    -
+      plugin: explode
+      source: alternative_title
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        value:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 0
+        target_id:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 1
+          -
+            plugin: entity_lookup
+            entity_type: taxonomy_term
+            bundle: language
+            bundle_key: vid
+            value_key: field_language_code
 destination:
   plugin: 'entity:node'
-  default_bundle: islandora_object
+  default_bundle: collection_object
 migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -168,7 +168,18 @@ test('Perform Collection Migration', async t => {
 
   await t
     .setFilesToUpload('#edit-source-file', [
-      './migrations/collection.csv'
+      './migrations/collection-01.csv'
+    ])
+    .click('#edit-import');
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_new_collection))
+    .expect(selectUpdateExistingRecords.checked).ok();  // n.b. checked by default
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/collection-02.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/collection-01.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/collection-01.csv
@@ -1,0 +1,3 @@
+local_id,title,title_language,alternative_title,member_of,contact_email,contact_name,collection_number,description,finding_aid
+collection-01,Parent Collection,,,,,,,,
+collection-02,Test Collection One,eng,Titre alternatif pour Test Collection One;fre|Alternate Title for Test Collection One;eng,,emetsger@gmail.com,Elliot Metsger,1|2,This is a description for Test Collection One;eng|Esta es una descripción de la colección de pruebas uno;spa,http://wikipedia.org;Wikipedia|http://www.google.com;Google

--- a/tests/10-migration-backend-tests/testcafe/migrations/collection-02.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/collection-02.csv
@@ -1,0 +1,3 @@
+local_id,title,title_language,alternative_title,member_of,contact_email,contact_name,collection_number,description,finding_aid
+collection-01,Parent Collection,,,,,,,,
+collection-02,Test Collection One,eng,Titre alternatif pour Test Collection One;fre|Alternate Title for Test Collection One;eng,collection-01,emetsger@gmail.com,Elliot Metsger,1|2,This is a description for Test Collection One;eng|Esta es una descripción de la colección de pruebas uno;spa,http://wikipedia.org;Wikipedia|http://www.google.com;Google

--- a/tests/10-migration-backend-tests/testcafe/migrations/collection.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/collection.csv
@@ -1,2 +1,0 @@
-local_id,name,description
-collection_1,Collection One,Photos by Ansel Adams

--- a/tests/10-migration-backend-tests/verification/expected/collection-01.json
+++ b/tests/10-migration-backend-tests/verification/expected/collection-01.json
@@ -1,41 +1,42 @@
 {
-  "type": "Collection",
-  "title": "Collection One",
-  "description": "Photos by Ansel Adams",
-  "member_of": [
-    "<id of collection or item>"
-  ],
-  "subjects": [
-    "<string 1>",
-    "<string 2>"
-  ],
-  "authority": [
-
-  ],
-
-  "display_hint": [
-
-  ],
-
-  "name": "",
-  "use": [
-
-  ],
-  "url": "",
-  "alt_titles": [
+  "type": "node",
+  "bundle": "collection_object",
+  "title": "Test Collection One",
+  "title_language": "eng",
+  "alternative_title": [
     {
-      "value": "alt title 1",
+      "value": "Titre alternatif pour Test Collection One",
+      "language": "fre"
+    },
+    {
+      "value": "Alternate Title for Test Collection One",
+      "language": "eng"
+    }
+  ],
+  "description": [
+    {
+      "value": "This is a description for Test Collection One",
       "language": "eng"
     },
     {
-      "value": "alt title 2",
-      "language": "ger"
+      "value": "Esta es una descripción de la colección de pruebas uno",
+      "language": "spa"
     }
   ],
-  "linked_agents": [
+  "contact_email": "emetsger@gmail.com",
+  "contact_name": "Elliot Metsger",
+  "collection_number": [
+    "1", "2"
+  ],
+  "member_of": "Parent Collection",
+  "finding_aid": [
     {
+      "uri": "http://wikipedia.org",
+      "title": "Wikipedia"
     },
     {
+      "uri": "http://www.google.com",
+      "title": "Google"
     }
   ]
 }

--- a/tests/10-migration-backend-tests/verification/expected/collection-01.json
+++ b/tests/10-migration-backend-tests/verification/expected/collection-01.json
@@ -28,7 +28,9 @@
   "collection_number": [
     "1", "2"
   ],
-  "member_of": "Parent Collection",
+  "member_of": [
+    "Parent Collection"
+  ],
   "finding_aid": [
     {
       "uri": "http://wikipedia.org",

--- a/tests/10-migration-backend-tests/verification/expected/collection-02.json
+++ b/tests/10-migration-backend-tests/verification/expected/collection-02.json
@@ -1,0 +1,5 @@
+{
+  "type": "node",
+  "bundle": "collection_object",
+  "title": "Parent Collection"
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -213,3 +213,27 @@ type ExpectedLanguage struct {
 		Processed string
 	}
 }
+
+// Represents the expected results of a migrated Collection entity
+type ExpectedCollection struct {
+  Type string
+  Bundle string
+  Title string
+  TitleLangCode string `json:"title_language"`
+  AltTitle []struct {
+    Value string
+    LangCode string `json:"language"`
+  }
+  Description []struct {
+    Value string
+    LangCode string `json:"language"`
+  }
+  ContactEmail string `json:"contact_email"`
+  ContactName string `json:"contact_name"`
+  CollectionNumber []string `json:"collection_number"`
+  MemberOf string
+  FindingAid []struct {
+    Uri string
+    Title string
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -216,24 +216,24 @@ type ExpectedLanguage struct {
 
 // Represents the expected results of a migrated Collection entity
 type ExpectedCollection struct {
-  Type string
-  Bundle string
-  Title string
-  TitleLangCode string `json:"title_language"`
-  AltTitle []struct {
-    Value string
-    LangCode string `json:"language"`
-  }
-  Description []struct {
-    Value string
-    LangCode string `json:"language"`
-  }
-  ContactEmail string `json:"contact_email"`
-  ContactName string `json:"contact_name"`
-  CollectionNumber []string `json:"collection_number"`
-  MemberOf string
-  FindingAid []struct {
-    Uri string
-    Title string
-  }
+	Type          string
+	Bundle        string
+	Title         string
+	TitleLangCode string `json:"title_language"`
+	AltTitle      []struct {
+		Value    string
+		LangCode string `json:"language"`
+	} `json:"alternative_title"`
+	Description []struct {
+		Value    string
+		LangCode string `json:"language"`
+	}
+	ContactEmail     string   `json:"contact_email"`
+	ContactName      string   `json:"contact_name"`
+	CollectionNumber []string `json:"collection_number"`
+	MemberOf         []string `json:"member_of"`
+	FindingAid       []struct {
+		Uri   string
+		Title string
+	}
 }

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -204,6 +204,52 @@ type JsonApiLanguage struct {
 	} `json:"data"`
 }
 
+// Represents the results of a JSONAPI query for a single collection entity
+type JsonApiCollection struct {
+  JsonApiData []struct {
+    Type              DrupalType
+    Id                string
+    JsonApiAttributes struct {
+      Title        string
+      Description struct {
+        Value     string
+        LangCode string
+      }
+      ContactEmail string `json:"field_collection_contact_email"`
+      ContactName string `json:"field_collection_contact_name"`
+      CollectionNumber []string `json:"field_collection_number"`
+      FindingAid []struct {
+        Uri string
+        Title string
+      } `json:"field_finding_aid"`
+    } `json:"attributes"`
+    JsonApiRelationships struct {
+      AltTitle struct {
+        Data []struct {
+          JsonApiData
+          Meta map[string]string
+        }
+        Links struct {
+          Related struct {
+            Href string
+          }
+        }
+      } `json:"field_alternative_title"`
+      TitleLanguage struct {
+        Data []struct {
+          JsonApiData
+          Meta map[string]string
+        }
+        Links struct {
+          Related struct {
+            Href string
+          }
+        }
+      } `json:"field_title_language"`
+    } `json:"relationships"`
+  } `json:"data"`
+}
+
 // Represents the results of a JSONAPI query for a single repository object
 type JsonApiRepoObj struct {
 	JsonApiData []struct {

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -273,6 +273,17 @@ type JsonApiCollection struct {
 					}
 				}
 			} `json:"field_title_language"`
+			Description struct {
+				Data []struct {
+					JsonApiData
+					Meta map[string]string
+				}
+			} `json:"field_description"`
+			MemberOf struct {
+				Data []struct {
+					JsonApiData
+				}
+			} `json:"field_member_of"`
 		} `json:"relationships"`
 	} `json:"data"`
 }
@@ -399,7 +410,7 @@ type JsonApiSubject struct {
 	} `json:"data"`
 }
 
-// Represents the results of a JSONAPI query for a single Family Taxonomy Term
+// Represents the results of a JSONAPI query for a single Language Taxonomy Term
 type JsonApiLanguage struct {
 	JsonApiData []struct {
 		Type              DrupalType

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -209,28 +209,6 @@ type JsonApiFamily struct {
 	} `json:"data"`
 }
 
-// Represents the results of a JSONAPI query for a single Family Taxonomy Term
-type JsonApiLanguage struct {
-	JsonApiData []struct {
-		Type              DrupalType
-		Id                string
-		JsonApiAttributes struct {
-			Name         string
-			LanguageCode string `json:"field_language_code"`
-			Description  struct {
-				Value     string
-				Format    string
-				Processed string
-			}
-			Authority []struct {
-				Uri    string
-				Title  string
-				Source string
-			} `json:"field_authority_link"`
-		} `json:"attributes"`
-	} `json:"data"`
-}
-
 // Represents the results of a JSONAPI query for a single collection entity
 type JsonApiCollection struct {
 	JsonApiData []struct {

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -371,3 +371,25 @@ type JsonApiSubject struct {
 		} `json:"attributes"`
 	} `json:"data"`
 }
+
+// Represents the results of a JSONAPI query for a single Family Taxonomy Term
+type JsonApiLanguage struct {
+         JsonApiData []struct {
+                 Type              DrupalType
+                 Id                string
+                 JsonApiAttributes struct {
+                         Name         string
+                         LanguageCode string `json:"field_language_code"`
+                         Description  struct {
+                                 Value     string
+                                 Format    string
+                                 Processed string
+                         }
+                         Authority []struct {
+                                 Uri    string
+                                 Title  string
+                                 Source string
+                         } `json:"field_authority_link"`
+                 } `json:"attributes"`
+         } `json:"data"`
+  }

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -252,10 +252,7 @@ type JsonApiCollection struct {
 		} `json:"attributes"`
 		JsonApiRelationships struct {
 			AltTitle struct {
-				Data []struct {
-					JsonApiData
-					Meta map[string]string
-				}
+				Data  []JsonApiLanguageValue
 				Links struct {
 					Related struct {
 						Href string
@@ -263,10 +260,7 @@ type JsonApiCollection struct {
 				}
 			} `json:"field_alternative_title"`
 			TitleLanguage struct {
-				Data struct {
-					JsonApiData
-					Meta map[string]string
-				}
+				Data  JsonApiLanguageValue
 				Links struct {
 					Related struct {
 						Href string
@@ -274,10 +268,7 @@ type JsonApiCollection struct {
 				}
 			} `json:"field_title_language"`
 			Description struct {
-				Data []struct {
-					JsonApiData
-					Meta map[string]string
-				}
+				Data []JsonApiLanguageValue
 			} `json:"field_description"`
 			MemberOf struct {
 				Data []struct {
@@ -430,4 +421,64 @@ type JsonApiLanguage struct {
 			} `json:"field_authority_link"`
 		} `json:"attributes"`
 	} `json:"data"`
+}
+
+// Represents an element of a JSONAPI response that encapsulates a string value and a language taxonomy entity
+//
+// In the following example, the objects with a type `taxonomy_term--language` are represented by this struct.
+//   "field_alternative_title": {
+//    "data": [
+//      {
+//        "type": "taxonomy_term--language",
+//        "id": "7397e0c4-df0a-4800-95af-afccc6ff64a5",
+//        "meta": {
+//          "value": "Moonrise Over Hernandez"
+//        }
+//      },
+//      {
+//        "type": "taxonomy_term--language",
+//        "id": "bacfc5b6-b4b9-4239-8744-46dca6a91f0e",
+//        "meta": {
+//          "value": "Salida de la luna sobre Hernández"
+//        }
+//      }
+//    ],
+//    "links": {
+//      "related": {
+//        "href": "http://islandora-idc.traefik.me/jsonapi/node/islandora_object/815a4c04-0be5-44f1-a876-e8ddc11dcf21/field_alternative_title?resourceVersion=id%3A48"
+//      },
+//      "self": {
+//        "href": "http://islandora-idc.traefik.me/jsonapi/node/islandora_object/815a4c04-0be5-44f1-a876-e8ddc11dcf21/relationships/field_alternative_title?resourceVersion=id%3A48"
+//      }
+//    }
+//  }
+type JsonApiLanguageValue struct {
+	t    assert.TestingT
+	Type DrupalType
+	Id   string
+	Meta struct {
+		Value string
+	}
+}
+
+// Answers the language code of the value string by resolving the Language Taxonomy entity identified in the
+// JsonApiLanguageValue
+func (lv JsonApiLanguageValue) langCode(t *testing.T) string {
+	u := JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: lv.Type.entity(),
+		drupalBundle: lv.Type.bundle(),
+		filter:       "id",
+		value:        lv.Id,
+	}
+
+	jsonApiLang := JsonApiLanguage{}
+	u.get(&jsonApiLang)
+	return jsonApiLang.JsonApiData[0].JsonApiAttributes.LanguageCode
+}
+
+// Answers the value of the string, the language of which is provided by langCode(...)
+func (lv JsonApiLanguageValue) value() string {
+	return lv.Meta.Value
 }

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -433,42 +433,54 @@ func Test_VerifyTaxonomyTermLanguage(t *testing.T) {
 }
 
 func Test_VerifyCollection(t *testing.T) {
-  expectedJson := ExpectedCollection{}
-  unmarshalJson(t, "collection-01.json", &expectedJson)
+	expectedJson := ExpectedCollection{}
+	unmarshalJson(t, "collection-01.json", &expectedJson)
 
-  // sanity check the expected json
-  assert.Equal(t, "node", expectedJson.Type)
-  assert.Equal(t, "collection_object", expectedJson.Bundle)
+	// sanity check the expected json
+	assert.Equal(t, "node", expectedJson.Type)
+	assert.Equal(t, "collection_object", expectedJson.Bundle)
 
-  u := &JsonApiUrl{
-    t:            t,
-    baseUrl:      DrupalBaseurl,
-    drupalEntity: expectedJson.Type,
-    drupalBundle: expectedJson.Bundle,
-    filter:       "title",
-    value:        expectedJson.Title,
-  }
+	u := &JsonApiUrl{
+		t:            t,
+		baseUrl:      DrupalBaseurl,
+		drupalEntity: expectedJson.Type,
+		drupalBundle: expectedJson.Bundle,
+		filter:       "title",
+		value:        expectedJson.Title,
+	}
 
-  // retrieve json of the migrated entity from the jsonapi and unmarshal the single response
-  res := &JsonApiCollection{}
-  u.get(res)
-  sourceId := res.JsonApiData[0].Id
-  assert.NotEmpty(t, sourceId)
+	// retrieve json of the migrated entity from the jsonapi and unmarshal the single response
+	res := &JsonApiCollection{}
+	u.get(res)
+	sourceId := res.JsonApiData[0].Id
+	assert.NotEmpty(t, sourceId)
 
-  actual := res.JsonApiData[0]
-  assert.Equal(t, expectedJson.Type, actual.Type.entity())
-  assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
-  assert.Equal(t, expectedJson.Title, actual.JsonApiAttributes.Title)
-  assert.Equal(t, expectedJson.ContactEmail, actual.JsonApiAttributes.ContactEmail)
-  assert.Equal(t, expectedJson.ContactName, actual.JsonApiAttributes.ContactName)
-  assert.ElementsMatch(t, expectedJson.CollectionNumber, actual.JsonApiAttributes.CollectionNumber)
+	actual := res.JsonApiData[0]
+	assert.Equal(t, expectedJson.Type, actual.Type.entity())
+	assert.Equal(t, expectedJson.Bundle, actual.Type.bundle())
+	assert.Equal(t, expectedJson.Title, actual.JsonApiAttributes.Title)
+	assert.Equal(t, expectedJson.ContactEmail, actual.JsonApiAttributes.ContactEmail)
+	assert.Equal(t, expectedJson.ContactName, actual.JsonApiAttributes.ContactName)
+	assert.ElementsMatch(t, expectedJson.CollectionNumber, actual.JsonApiAttributes.CollectionNumber)
 
-  relData := res.JsonApiData[0].JsonApiRelationships
+	relData := res.JsonApiData[0].JsonApiRelationships
+	assert.NotNil(t, relData.TitleLanguage.Data)
 
-  // Resolve and verify title language
-  assert.Equal(t, "taxonomy_term", relData.TitleLanguage.Data[0].Type.entity())
-  assert.Equal(t, "language", relData.TitleLanguage.Data[0].Type.bundle())
-  relRes, err := http.Get(relData.TitleLanguage.Links.Related.Href)
+	// Resolve and verify title language
+	assert.Equal(t, "taxonomy_term", relData.TitleLanguage.Data.Type.entity())
+	assert.Equal(t, "language", relData.TitleLanguage.Data.Type.bundle())
+	httpRes, body := getResource(t, relData.TitleLanguage.Links.Related.Href)
+	jsonApiRes := &JsonApiResponse{}
+	langRel := &JsonApiLanguage{}
+	unmarshalSingleResponse(t, body, httpRes, jsonApiRes).to(langRel)
+	assert.Equal(t, expectedJson.TitleLangCode, langRel.JsonApiData[0].JsonApiAttributes.LanguageCode)
+	//
+	//// Resolve and verify alternate title values and languages
+	//for i, altRel := range relData.AltTitle.Data {
+	//
+	//}
+	//
+	//httpRes, body := getResource(t, relData.AltTitle.Links.Related.Href)
 }
 
 func Test_VerifyRepositoryItem(t *testing.T) {

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -469,11 +469,7 @@ func Test_VerifyCollection(t *testing.T) {
 	assert.NotNil(t, relData.TitleLanguage.Data)
 	assert.Equal(t, "taxonomy_term", relData.TitleLanguage.Data.Type.entity())
 	assert.Equal(t, "language", relData.TitleLanguage.Data.Type.bundle())
-	httpRes, body := getResource(t, relData.TitleLanguage.Links.Related.Href)
-	jsonApiRes := &JsonApiResponse{}
-	langRel := &JsonApiLanguage{}
-	unmarshalSingleResponse(t, body, httpRes, jsonApiRes).to(langRel)
-	assert.Equal(t, expectedJson.TitleLangCode, langRel.JsonApiData[0].JsonApiAttributes.LanguageCode)
+	assert.Equal(t, expectedJson.TitleLangCode, relData.TitleLanguage.Data.langCode(t))
 
 	// Resolve and verify alternate title values and languages
 	assert.NotNil(t, relData.AltTitle.Data)
@@ -482,20 +478,8 @@ func Test_VerifyCollection(t *testing.T) {
 	for i, altTitleData := range relData.AltTitle.Data {
 		assert.Equal(t, "taxonomy_term", altTitleData.Type.entity())
 		assert.Equal(t, "language", altTitleData.Type.bundle())
-		assert.Equal(t, expectedJson.AltTitle[i].Value, altTitleData.Meta["value"])
-
-		u = &JsonApiUrl{
-			t:            t,
-			baseUrl:      DrupalBaseurl,
-			drupalEntity: altTitleData.Type.entity(),
-			drupalBundle: altTitleData.Type.bundle(),
-			filter:       "id",
-			value:        altTitleData.Id,
-		}
-		lang := JsonApiLanguage{}
-		u.get(&lang)
-
-		assert.Equal(t, expectedJson.AltTitle[i].LangCode, lang.JsonApiData[0].JsonApiAttributes.LanguageCode)
+		assert.Equal(t, expectedJson.AltTitle[i].Value, altTitleData.value())
+		assert.Equal(t, expectedJson.AltTitle[i].LangCode, altTitleData.langCode(t))
 	}
 
 	// Resolve and verify description values and languages
@@ -505,20 +489,8 @@ func Test_VerifyCollection(t *testing.T) {
 	for i, descData := range relData.Description.Data {
 		assert.Equal(t, "taxonomy_term", descData.Type.entity())
 		assert.Equal(t, "language", descData.Type.bundle())
-		assert.Equal(t, expectedJson.Description[i].Value, descData.Meta["value"])
-
-		u = &JsonApiUrl{
-			t:            t,
-			baseUrl:      DrupalBaseurl,
-			drupalEntity: descData.Type.entity(),
-			drupalBundle: descData.Type.bundle(),
-			filter:       "id",
-			value:        descData.Id,
-		}
-		lang := JsonApiLanguage{}
-		u.get(&lang)
-
-		assert.Equal(t, expectedJson.Description[i].LangCode, lang.JsonApiData[0].JsonApiAttributes.LanguageCode)
+		assert.Equal(t, expectedJson.Description[i].Value, descData.value())
+		assert.Equal(t, expectedJson.Description[i].LangCode, descData.langCode(t))
 	}
 
 	// Resolve and verify member_of values


### PR DESCRIPTION
Adds a Collection Object migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/collection-0[12].csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/collection-0[12].json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the list of content.
4. Observe the presence of two collections; these nodes are added by the test included in this PR.  `Test Collection One` and `Parent Collection`.
5. Select `Test Collection One`
6. Observe a number of characteristics:
* the Title Language is English
* two alternate titles, one each in French and Spanish
* two descriptions, one each in English and Spanish
* Collection Contact Name and Email are present
* Two collection numbers
* Two finding aids
* A link to the Parent Collection