### PR TITLE
Corporate Body taxonomy migration

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-14-g09641e3
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-193-g9aa764ad.1613010744
+SNAPSHOT_TAG=upstream-20201007-739693ae-197-g00975948.1613012322
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_corporatebody.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_taxonomy_corporatebody.yml
@@ -1,0 +1,135 @@
+uuid: 7c589bb5-2b1a-4383-ad22-e33caa3782c8
+langcode: en
+status: true
+dependencies: {  }
+id: idc_ingest_taxonomy_corporatebody
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: null
+migration_group: idc_ingest
+label: 'Taxonomy: Corporate Body'
+source:
+  plugin: csv
+  ids:
+    - local_id
+  path: 'Will be populated by the Migrate Source UI'
+process:
+  name: name
+  field_date_of_meeting_or_treaty: date_of_meeting_or_treaty
+  field_location_of_meeting: location_of_meeting
+  field_num_of_section_or_meet: num_of_section_or_meet
+  field_primary_name: primary_name
+  field_subordinate_name: subordinate_name
+  field_alt_date_of_meeting: alt_date_of_meeting
+  field_alt_location_of_meeting: alt_location_of_meeting
+  field_alt_num_of_section_or_meet: alt_number_of_section_or_meeting
+  field_alt_primary_name: alt_primary_name
+  field_alt_subordinate_name: alt_subordinate_name
+  description/value: description
+  description/format:
+    plugin: default_value
+    default_value: basic_html
+  field_authority_link:
+    -
+      plugin: explode
+      source: authority
+      delimiter: '|'
+      strict: false
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        uri:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 0
+        title:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 1
+        source:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            source: value
+            delimiter: ;
+          -
+            plugin: extract
+            index:
+              - 2
+  field_date:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: date
+    -
+      plugin: explode
+      delimiter: '|'
+  field_relationships:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: relationships
+    -
+      plugin: explode
+      delimiter: '|'
+    -
+      plugin: deepen
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 0
+          -
+            plugin: migration_lookup
+            migration: idc_ingest_taxonomy_corporatebody
+            no_stub: true
+        rel_type:
+          -
+            plugin: skip_on_empty
+            method: process
+            source: value
+          -
+            plugin: explode
+            delimiter: ';'
+          -
+            plugin: extract
+            index:
+              - 1
+destination:
+  plugin: 'entity:taxonomy_term'
+  default_bundle: corporate_body
+migration_dependencies: null

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -21,6 +21,7 @@ const migrate_new_collection = 'idc_ingest_new_collection';
 const migrate_media_images = 'idc_ingest_media_images';
 const migrate_resource_types = 'idc_ingest_taxonomy_resourcetypes';
 const migrate_subject_taxonomy = 'idc_ingest_taxonomy_subject';
+const migrate_corporatebody_taxonomy = 'idc_ingest_taxonomy_corporatebody';
 
 const selectMigration = Selector('#edit-migrations');
 const migrationOptions = selectMigration.find('option');
@@ -155,6 +156,31 @@ test('Perform Language Migration', async t => {
   await t
     .setFilesToUpload('#edit-source-file', [
       './migrations/language.csv'
+    ])
+    .click('#edit-import');
+
+});
+
+test('Perform Corporate Body Taxonomy Migration', async t => {
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_corporatebody_taxonomy));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/corporatebody-01.csv'
+    ])
+    .click('#edit-import');
+
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', migrate_corporatebody_taxonomy))
+    .expect(selectUpdateExistingRecords.checked).ok();  // n.b. checked by default
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      './migrations/corporatebody-02.csv'
     ])
     .click('#edit-import');
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/corporatebody-01.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/corporatebody-01.csv
@@ -1,0 +1,3 @@
+local_id,name,primary_name,subordinate_name,date_of_meeting_or_treaty,location_of_meeting,num_of_section_or_meet,alt_date_of_meeting,alt_location_of_meeting,alt_number_of_section_or_meeting,alt_primary_name,alt_subordinate_name,relationships,date,authority,description
+corp_01,Parent Corporate Body,Parent Corporate Body,,,,,,,,,,,2021|2022,,<p>This is a parent corporate body</p>
+corp_02,My Corporate Body,My Corporate Body,My Corporate Body Subordinate Name,2021,"Denver, CO",1st,2022,Alt Location Of Meeting,Alt Number of section or meeting,Alt Primary Corporate Name,Alt Subordinate Name,,2021|2022,http://loc.gov;LOC;lcnaf|http://www.google.com;Google Alt Link;other,<p>A corporate body description.</p>

--- a/tests/10-migration-backend-tests/testcafe/migrations/corporatebody-02.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/corporatebody-02.csv
@@ -1,0 +1,3 @@
+local_id,name,primary_name,subordinate_name,date_of_meeting_or_treaty,location_of_meeting,num_of_section_or_meet,alt_date_of_meeting,alt_location_of_meeting,alt_number_of_section_or_meeting,alt_primary_name,alt_subordinate_name,relationships,date,authority,description
+corp_01,Parent Corporate Body,Parent Corporate Body,,,,,,,,,,corp_02;schema:subOrganization,2021|2022,,<p>This is a parent corporate body</p>
+corp_02,My Corporate Body,My Corporate Body,My Corporate Body Subordinate Name,2021,"Denver, CO",1st,2022,Alt Location Of Meeting,Alt Number of section or meeting,Alt Primary Corporate Name,Alt Subordinate Name,corp_01;schema:parentOrganization,2021|2022,http://loc.gov;LOC;lcnaf|http://www.google.com;Google Alt Link;other,<p>A corporate body description.</p>

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-01.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-01.json
@@ -11,5 +11,11 @@
     "2021",
     "2022"
   ],
-  "primary_name": "Parent Corporate Body"
+  "primary_name": "Parent Corporate Body",
+  "relationships": [
+    {
+      "rel_type": "schema:subOrganization",
+      "name": "My Corporate Body"
+    }
+  ]
 }

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-01.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-01.json
@@ -1,0 +1,15 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "corporate_body",
+  "name": "Parent Corporate Body",
+  "description": {
+    "value": "<p>This is a parent corporate body</p>",
+    "format": "basic_html",
+    "processed": "<p>This is a parent corporate body</p>"
+  },
+  "date:": [
+    "2021",
+    "2022"
+  ],
+  "primary_name": "Parent Corporate Body"
+}

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-02.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-02.json
@@ -20,20 +20,23 @@
   "authority": [
     {
       "uri": "http://loc.gov",
-      "name": "LOC",
+      "title": "LOC",
       "source": "lcnaf"
     },
     {
       "uri": "http://www.google.com",
-      "name": "Google Alt Link",
+      "title": "Google Alt Link",
       "source": "other"
     }
   ],
-  "date:": [
+  "date": [
     "2021",
     "2022"
   ],
-  "parentOrganization": [
-    "Parent Corporate Body"
+  "relationships": [
+    {
+      "rel_type": "schema:parentOrganization",
+      "name": "Parent Corporate Body"
+    }
   ]
 }

--- a/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-02.json
+++ b/tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-02.json
@@ -1,0 +1,39 @@
+{
+  "type": "taxonomy_term",
+  "bundle": "corporate_body",
+  "name": "My Corporate Body",
+  "description": {
+    "value": "<p>A corporate body description.</p>",
+    "format": "basic_html",
+    "processed": "<p>A corporate body description.</p>"
+  },
+  "date_of_meeting_or_treaty": "2021",
+  "location_of_meeting": "Denver, CO",
+  "num_of_section_or_meet": "1st",
+  "primary_name": "My Corporate Body",
+  "subordinate_name": "My Corporate Body Subordinate Name",
+  "alt_date_of_meeting": "2022",
+  "alt_location_of_meeting": "Alt Location Of Meeting",
+  "alt_number_of_section_or_meeting": "Alt Number of section or meeting",
+  "alt_primary_name": "Alt Primary Corporate Name",
+  "alt_subordinate_name": "Alt Subordinate Name",
+  "authority": [
+    {
+      "uri": "http://loc.gov",
+      "name": "LOC",
+      "source": "lcnaf"
+    },
+    {
+      "uri": "http://www.google.com",
+      "name": "Google Alt Link",
+      "source": "other"
+    }
+  ],
+  "date:": [
+    "2021",
+    "2022"
+  ],
+  "parentOrganization": [
+    "Parent Corporate Body"
+  ]
+}

--- a/tests/10-migration-backend-tests/verification/expected_json_types_test.go
+++ b/tests/10-migration-backend-tests/verification/expected_json_types_test.go
@@ -237,3 +237,35 @@ type ExpectedCollection struct {
 		Title string
 	}
 }
+
+// Represents the expected results of a migrated Corporate Body taxonomy term
+type ExpectedCorporateBody struct {
+	Type        string
+	Bundle      string
+	Name        string
+	Description struct {
+		Value     string
+		Format    string
+		Processed string
+	}
+	PrimaryName        string `json:"primary_name"`
+	SubordinateName    string `json:"subordinate_name"`
+	DateOfMeeting      string `json:"date_of_meeting_or_treaty"`
+	Location           string `json:"location_of_meeting"`
+	NumberOrSection    string `json:"num_of_section_or_meet"`
+	AltDate            string `json:"alt_date_of_meeting"`
+	AltLocation        string `json:"alt_location_of_meeting"`
+	AltNumberOrSection string `json:"alt_number_of_section_or_meeting"`
+	AltPrimaryName     string `json:"alt_primary_name"`
+	AltSubordinateName string `json:"alt_subordinate_name"`
+	Authority          []struct {
+		Uri    string
+		Title  string
+		Source string
+	}
+	Date         []string
+	Relationship []struct {
+		Name string
+		Rel  string `json:"rel_type"`
+	} `json:"relationships"`
+}

--- a/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
+++ b/tests/10-migration-backend-tests/verification/jsonapi_types_test.go
@@ -460,3 +460,43 @@ func (lv JsonApiLanguageValue) langCode(t *testing.T) string {
 func (lv JsonApiLanguageValue) value() string {
 	return lv.Meta.Value
 }
+
+// Represents the results of a JSONAPI query for a single Corporate Body Term
+type JsonApiCorporateBody struct {
+	JsonApiData []struct {
+		Type              DrupalType
+		Id                string
+		JsonApiAttributes struct {
+			Name        string
+			Description struct {
+				Value     string
+				Format    string
+				Processed string
+			}
+			Authority []struct {
+				Uri    string
+				Title  string
+				Source string
+			} `json:"field_authority_link"`
+			AltDate            string   `json:"field_alt_date_of_meeting"`
+			AltLocation        string   `json:"field_alt_location_of_meeting"`
+			AltNumberOrSection string   `json:"field_alt_num_of_section_or_meet"`
+			AltPrimaryName     string   `json:"field_alt_primary_name"`
+			AltSubordinateName string   `json:"field_alt_subordinate_name"`
+			Date               []string `json:"field_date"`
+			DateOfMeeting      string   `json:"field_date_of_meeting_or_treaty"`
+			Location           string   `json:"field_location_of_meeting"`
+			NumberOrSection    string   `json:"field_num_of_section_or_meet"`
+			PrimaryName        string   `json:"field_primary_name"`
+			SubordinateName    string   `json:"field_subordinate_name"`
+		} `json:"attributes"`
+		JsonApiRelationships struct {
+			Relationships struct {
+				Data []struct {
+					JsonApiData
+					Meta map[string]string
+				}
+			} `json:"field_relationships"`
+		} `json:"relationships"`
+	} `json:"data"`
+}


### PR DESCRIPTION
Adds a Corporate Body Taxonomy migration test.

Test CSV is located in `tests/10-migration-backend-tests/testcafe/migrations/corporatebody-0[12].csv`
Expected result is located in `tests/10-migration-backend-tests/verification/expected/taxonomy-corporatebody-0[12].json`

To review:
1. Run `make reset`
2. Run `tests/10-migration-backend-tests.sh`, observe tests pass.
3. Optionally, login to Drupal and navigate to the Corporate Body Taxonomy.
4. Observe two entries, added by the test included in this PR
5. Select `Parent Corporation`
6. Observe it has a `Sub-Organization` relationship with `My Corporate Body`
7. Navigate to the `My Corporate Body` entry
6. Observe that it has a number of fields including:
* Name
* Primary name
* Subordinate Name
* Location Of Meeting
* Number of section or meeting
* Date of meeting
* Alternate Primary corporate name
* Alternate Subordinate name
* Alternate location of meeting
* Alternate Number of section or meeting
* Alternate Date of meeting
* Two authority sources
* Two dates
* And a `Parent Organization` link back to `Parent Corporate Body`