### PR TITLE
Incorporate buildkit updates and fixes

### DIFF
--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-14-g09641e3
+TAG=upstream-20200824-f8d1e8e-20-g6884c2e
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-197-g00975948.1613012322


### PR DESCRIPTION
Image tag is updated to encompass:
 * service security updates and upgrades
   https://github.com/jhu-idc/idc-isle-buildkit/pull/27

 * additional parameters for setting nginx buffer size
   https://github.com/jhu-idc/idc-isle-buildkit/pull/29
   
##To test:

Each buildkit PR has been manually tested already against `idc-isle-dc`.  Elliot:  verify that applying the `TAG` in this PR to your failing migration test scenario (due to nginx buffers filling) results in a fix.