### PR TITLE
Enhance Drupal customization via environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-14-g09641e3
+TAG=upstream-20200824-f8d1e8e-22-gc815aed
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-200-g61fbe54.1614195494

--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-22-gc815aed
+TAG=upstream-20200824-f8d1e8e-23-g9fe79fc
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-200-g61fbe54.1614195494

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
             - name: Build Static 
               run: docker-compose down -v && make static-docker-compose.yml up
 
+            # Drush tests
+            - name: Drush test
+              run: docker-compose exec -T drupal drush -d status
+
             # Run end-to-end tests
             - name: End-To-End Tests
               run: | 

--- a/codebase/web/sites/default/settings.local.php
+++ b/codebase/web/sites/default/settings.local.php
@@ -5,12 +5,12 @@ $settings['hash_salt'] = getenv('DRUPAL_DEFAULT_SALT');
 
 $settings['config_sync_directory'] = '/var/www/drupal/config/sync';
 
-$databases['default']['default']['database'] =  getenv('DRUPAL_DEFAULT_DB_NAME') ?? 'drupal+default';
-$databases['default']['default']['username'] =  getenv('DRUPAL_DEFAULT_DB_USER') ?? 'drupal_default';
+$databases['default']['default']['database'] =  getenv('DRUPAL_DEFAULT_DB_NAME') ?: 'drupal_default';
+$databases['default']['default']['username'] =  getenv('DRUPAL_DEFAULT_DB_USER') ?: 'drupal_default';
 $databases['default']['default']['password'] =  getenv('DRUPAL_DEFAULT_DB_PASSWORD');
-$databases['default']['default']['host'] =  getenv('DRUPAL_DEFAULT_DB_HOST') ?? 'database';
-$databases['default']['default']['port'] =  getenv('DRUPAL_DEFAULT_DB_PORT') ?? '3306';
+$databases['default']['default']['host'] =  getenv('DRUPAL_DEFAULT_DB_HOST') ?: 'database';
+$databases['default']['default']['port'] =  getenv('DRUPAL_DEFAULT_DB_PORT') ?: '3306';
 $databases['default']['default']['prefix'] = '';
-$databases['default']['default']['driver'] = getenv('DRUPAL_DEFAULT_DB_DRIVER') ?? 'mysql';
+$databases['default']['default']['driver'] = getenv('DRUPAL_DEFAULT_DB_DRIVER') ?: 'mysql';
 $databases['default']['default']['namespace']  = 'Drupal\\Core\\Database\\Driver\\';
 $databases['default']['default']['namespace'] .= $databases['default']['default']['driver'];

--- a/codebase/web/sites/default/settings.local.php
+++ b/codebase/web/sites/default/settings.local.php
@@ -1,0 +1,16 @@
+<?php
+
+
+$settings['hash_salt'] = getenv('DRUPAL_DEFAULT_SALT');
+
+$settings['config_sync_directory'] = '/var/www/drupal/config/sync';
+
+$databases['default']['default']['database'] =  getenv('DRUPAL_DEFAULT_DB_NAME') ?? 'drupal+default';
+$databases['default']['default']['username'] =  getenv('DRUPAL_DEFAULT_DB_USER') ?? 'drupal_default';
+$databases['default']['default']['password'] =  getenv('DRUPAL_DEFAULT_DB_PASSWORD');
+$databases['default']['default']['host'] =  getenv('DRUPAL_DEFAULT_DB_HOST') ?? 'database';
+$databases['default']['default']['port'] =  getenv('DRUPAL_DEFAULT_DB_PORT') ?? '3306';
+$databases['default']['default']['prefix'] = '';
+$databases['default']['default']['driver'] = getenv('DRUPAL_DEFAULT_DB_DRIVER') ?? 'mysql';
+$databases['default']['default']['namespace']  = 'Drupal\\Core\\Database\\Driver\\';
+$databases['default']['default']['namespace'] .= $databases['default']['default']['driver'];

--- a/codebase/web/sites/default/settings.php
+++ b/codebase/web/sites/default/settings.php
@@ -789,27 +789,6 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
  * Keep this code block at the end of this file to take full effect.
  */
 #
-# if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
-#   include $app_root . '/' . $site_path . '/settings.local.php';
-# }
-$settings['config_sync_directory'] = '/var/www/drupal/config/sync';
-$databases['default']['default'] = array (
-  'database' => 'drupal_default',
-  'username' => 'drupal_default',
-  'password' => 'password',
-  'prefix' => '',
-  'host' => 'mariadb-idc.traefik.me',
-  'port' => '3306',
-  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
-  'driver' => 'mysql',
-);
-$settings['flysystem']['fedora']['driver'] = 'fedora';
-$settings['flysystem']['fedora']['config']['root'] = 'http://fcrepo.isle-dc.localhost/fcrepo/rest/';
-$databases['default']['default']['database'] = 'drupal_default';
-$databases['default']['default']['username'] = 'drupal_default';
-$databases['default']['default']['password'] = 'password';
-$databases['default']['default']['host'] = 'mariadb-idc.traefik.me';
-$databases['default']['default']['port'] = '3306';
-$databases['default']['default']['prefix'] = '';
-$databases['default']['default']['driver'] = 'mysql';
-$databases['default']['default']['namespace'] = 'Drupal\\Core\\Database\\Driver\\mysql';
+if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
+  include $app_root . '/' . $site_path . '/settings.local.php';
+}


### PR DESCRIPTION
* Creates a `settings.local.php` file for all local customizations
* Uses latest buildkit images that expose environment variables to php
* Uses `getenv()` for configuration values in `settings.local.php` that depend on external configuration

## To Test
* Minimal test:  Just make sure tests pass
* More thorough test,  do a `docker-compose down -v`, edit `DRUPAL_DEFAULT_DB_PASSWORD` in `.env`, then `make up`.  It should come up OK.

Resolves jhu-idc/idc-isle-buildkit#25