### PR TITLE
Increase specificity of GH actions build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,5 @@ jobs:
             - name: Docker Push
               if: |
                 ${{ env.DOCKER_USER != null }} &&
-                contains('refs/heads/development
-                          refs/heads/main
-                ', github.ref)
+                contains(['refs/heads/development', 'refs/heads/main'], github.ref)
               run: docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@ jobs:
         timeout-minutes: 30
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
-          GITHUB_REF: ${{github.ref}}
         steps:
             # Check out current commit
             - name: Checkout
               uses: actions/checkout@v2
+
+            # Debugging
+            - name: Testing
+              run: echo ${{github.ref}}
 
             # Make sure buildkit is enabled
             - name: Enable buildkit
@@ -62,7 +65,6 @@ jobs:
             
             # Push docker images
             - name: Docker Push
-              if: |
-                contains(['refs/heads/development', 'refs/heads/main'], github.ref) &&
+              if: contains(['refs/heads/development', 'refs/heads/main'], github.ref) &&
                 ${{ env.DOCKER_USER != null }}
-              run: echo "Github ref ${GITHUB_REF}" && docker-compose push drupal
+              run: docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
             # Debugging
             - name: Testing contains pull
-              if: contains(github.ref, "refs/pull")
+              if: contains(github.ref, 'refs/pull')
               run: echo "It's a pull request"
 
             - name: Testing contains string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
               if: contains('refs/heads/main refs/heads/development', github.ref)
               run: echo "It's main or development"
 
+            - name: Testing contains string 2
+              if: contains('refs/heads/main 
+                            refs/heads/development', github.ref)
+              run: echo "It's main or development"
+
+            - name: Testing contains string 3
+              if: contains('refs/heads/main 
+                            refs/heads/development', github.ref) &&
+                   ${{ env.DOCKER_USER != null }}
+              run: echo "It's main or development"            
+
             - name: Stop
               run: exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - development
+  pull_request:
+    branches:
+      - main
+      - development
 
 jobs:
     everything:
@@ -53,5 +61,9 @@ jobs:
             
             # Push docker images
             - name: Docker Push
-              if:  ${{ env.DOCKER_USER != null }}
+              if: |
+                ${{ env.DOCKER_USER != null }} &&
+                contains('refs/heads/development
+                          refs/heads/main
+                ', github.ref)
               run: docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,18 @@ jobs:
             - name: Testing contains string 3
               if: contains('refs/heads/main 
                             refs/heads/development', github.ref) &&
-                   ${{ env.DOCKER_USER != null }}
-              run: echo "It's main or development"            
+                   env.DOCKER_USER != null
+              run: echo "It's main or development, and docker user is not null"
+
+            - name: Testing conjunction 1
+              if: contains(github.ref, 'refs/pull') && 
+                    env.DOCKER_USER != null
+              run: echo "It's a pull request, and docker user is not null"  
+
+            - name: Testing conjunction 2
+              if: contains(github.ref, 'refs/pull') && 
+                    env.DOCKER_USER == null
+              run: echo "It's a pull request, and docker user is null"              
 
             - name: Stop
               run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,20 @@ jobs:
               uses: actions/checkout@v2
 
             # Debugging
-            - name: Testing
-              run: echo ${{github.ref}}
+            - name: Testing contains pull
+              if: contains(github.ref, "refs/pull")
+              run: echo "It's a pull request"
+
+            - name: Testing contains string
+              if: contains('refs/heads/main refs/heads/development', github.ref)
+              run: echo "It's main or development"
+
+            - name: Testing contains list
+              if: contains(['refs/heads/development', 'refs/heads/main'], github.ref)
+              run: echo "It's main or development"
+
+            - name: Stop
+              run: exit 1
 
             # Make sure buildkit is enabled
             - name: Enable buildkit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,39 +21,6 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
 
-            # Debugging
-            - name: Testing contains pull
-              if: contains(github.ref, 'refs/pull')
-              run: echo "It's a pull request"
-
-            - name: Testing contains string
-              if: contains('refs/heads/main refs/heads/development', github.ref)
-              run: echo "It's main or development"
-
-            - name: Testing contains string 2
-              if: contains('refs/heads/main 
-                            refs/heads/development', github.ref)
-              run: echo "It's main or development"
-
-            - name: Testing contains string 3
-              if: contains('refs/heads/main 
-                            refs/heads/development', github.ref) &&
-                   env.DOCKER_USER != null
-              run: echo "It's main or development, and docker user is not null"
-
-            - name: Testing conjunction 1
-              if: contains(github.ref, 'refs/pull') && 
-                    env.DOCKER_USER != null
-              run: echo "It's a pull request, and docker user is not null"  
-
-            - name: Testing conjunction 2
-              if: contains(github.ref, 'refs/pull') && 
-                    env.DOCKER_USER == null
-              run: echo "It's a pull request, and docker user is null"              
-
-            - name: Stop
-              run: exit 1
-
             # Make sure buildkit is enabled
             - name: Enable buildkit
               shell: bash
@@ -85,15 +52,18 @@ jobs:
 
             # Log in to Docker, if we have the secrets
             - name: Docker Login
-              if: ${{ env.DOCKER_USER != null }}
+              if: contains('refs/heads/main 
+                            refs/heads/development', github.ref) &&
+                  env.DOCKER_USER != null
               uses: docker/login-action@v1
               with:
                 registry: ghcr.io
                 username: ${{ env.DOCKER_USER }}
                 password: ${{ secrets.DOCKER_PASS }}
             
-            # Push docker images
+            # Push docker images, if we are on the appropriate branch or tag
             - name: Docker Push
-              if: contains(['refs/heads/development', 'refs/heads/main'], github.ref) &&
-                ${{ env.DOCKER_USER != null }}
+              if: contains('refs/heads/main 
+                            refs/heads/development', github.ref) &&
+                  env.DOCKER_USER != null
               run: docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         timeout-minutes: 30
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
+          GITHUB_REF: ${{github.ref}}
         steps:
             # Check out current commit
             - name: Checkout
@@ -62,6 +63,6 @@ jobs:
             # Push docker images
             - name: Docker Push
               if: |
-                ${{ env.DOCKER_USER != null }} &&
-                contains(['refs/heads/development', 'refs/heads/main'], github.ref)
-              run: docker-compose push drupal
+                contains(['refs/heads/development', 'refs/heads/main'], github.ref) &&
+                ${{ env.DOCKER_USER != null }}
+              run: echo "Github ref ${GITHUB_REF}" && docker-compose push drupal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
               if: contains('refs/heads/main refs/heads/development', github.ref)
               run: echo "It's main or development"
 
-            - name: Testing contains list
-              if: contains(['refs/heads/development', 'refs/heads/main'], github.ref)
-              run: echo "It's main or development"
-
             - name: Stop
               run: exit 1
 


### PR DESCRIPTION
* Building from pull requests is now mutually exclusive to building on
pushes to main or development (previously, any push would trigger a
build, so all PRs would inherently have two builds)

* Do not attempt to push docker images from pull requests.  Only
  build upon push to main or development

## To test:
Look at actions yaml file, look at builds for this PR.  There should be only _one_ full build (ignore the dependency diff checks), and that build should not attempt to push docker images.

Resolves #54 