### PR TITLE
Drupal PHP debugging support

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,11 @@
 # rather than defined in `env-file` files.
 
 # Determines which docker-compose file(s) will be used for the `drupal` service.
-# See documentation for more details.
+# Valid values are 'local', progenitor of the production image, or 'drupal-dev',
+# which precedes the development image, including remote debugging support.
+#
+# If this value is changed, docker-compose.yml must be updated in order for it
+# to take effect; e.g. 'make dev-up'
 ENVIRONMENT=local
 
 REQUIRED_SERIVCES=activemq alpaca cantaloupe idc-crayfish crayfits drupal mariadb solr idc-snapshot testcafe
@@ -66,7 +70,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-25-g01c1c7a
+TAG=upstream-20200824-f8d1e8e-26-g09f74e4
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-251-g0145185.1618855066

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ codebase/web/core/
 codebase/web/modules/contrib/
 codebase/web/themes/contrib/
 snapshot/data.tar
+xdebug*
 
 # =========================
 # Packages

--- a/docker-compose.drupal-dev.yml
+++ b/docker-compose.drupal-dev.yml
@@ -1,0 +1,59 @@
+# Drupal Debugging Container configuration
+#
+# Isolates development-related container modifications, including remote debugging configuration. Updates to
+# docker-compose.local.yml should be replicated here.
+#
+# This file is used when 'ENVIRONMENT' is equal to 'drupal-dev' in the .env file, otherwise it is ignored.
+version: "3.7"
+networks:
+  default:
+    internal: true
+  gateway:
+    external:
+      name: gateway
+volumes:
+  drupal-sites-data:
+  solr-data:
+services:
+  drupal:
+    image: ${REPOSITORY:-islandora}/drupal-dev:${TAG:-latest}
+      # Uncomment below to PHP commands executed on container start, or PHP commands (e.g. drush) run from the CLI
+      # (significantly slows down the container startup)
+      # If debugging container startup is not necessary, consider setting the environment variables within a shell via
+      # `docker-compose exec drupal-dev /bin/bash`
+      #environment:
+      # These env vars regulate command line debugging; xdebug.ini regulates web-based debugging.  Enabling CLI
+      # debugging severely impacts container startup performance.  If all you need to do is debug a single PHP command,
+      # consider `exec`ing into the container, exporting the variables you see below, and run the command.
+      # https://xdebug.org/docs/all_settings#XDEBUG_CONFIG
+      # https://xdebug.org/docs/step_debug#activate_debugger
+      #XDEBUG_CONFIG: "client_host=host.docker.internal log=/tmp/xdebug-cmdline.log"
+      #XDEBUG_SESSION: 1
+
+      # These env vars regulate web-based debugging, resulting in updates to /etc/php7/conf.d/xdebug.ini.  Default
+      # values used for xdebug.ini are below.  Uncomment and change the value to override.
+      #XDEBUG_MODE: "develop,debug,trace"
+      #XDEBUG_LOG: "/var/www/drupal/xdebug.log"
+      #XDEBUG_LOGLEVEL: "7"
+      #XDEBUG_DISCOVERCLIENTHOST: "false"
+      #XDEBUG_CLIENTHOST: "host.docker.internal"
+    volumes:
+      - ./codebase:/var/www/drupal:delegated
+      - drupal-sites-data:/var/www/drupal/web/sites/default/files
+      #- solr-data:/opt/solr/server/solr
+    depends_on:
+      # Requires a the very minimum a database.
+      - ${DRUPAL_DATABASE_SERVICE}
+    secrets:
+      - source: saml_secrets
+  # Extends docker-compose.solr.yml
+  solr:
+    volumes:
+      # On a production site you may not want to take this approach but instead refer to each of the cores
+      # data directories specifically and maintain the configuration as part of a customized image, where
+      # in your configuration is Solr managed under source control somewhere.
+      - solr-data:/opt/solr/server/solr
+
+secrets:
+  saml_secrets:
+    file: ./secrets/saml-secrets.yml


### PR DESCRIPTION
## Instructions for testing

1. Install an XDebug [browser extension](https://xdebug.org/docs/step_debug#browser-extensions)
1. Stop the Drupal stack, bring the environment down. (`docker-compose down`)
1. Check out this PR
1. Run `make dev-up`.  After running `make dev-up`, observe that the `.env` file  has `drupal-dev` as the value for `ENVIRONMENT`, and `docker-compose.yml` should reference the `drupal-dev` image instead of `drupal`.
1. Verify the output of `docker ps` includes `ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-dev`
1. Open your IDE and configure a development session for XDebug, set a breakpoint, say in `codebase/web/index.php`.  Your IDE will need to listen on port `9003`, the standard port for XDebug.
1. Enable the XDebug browser extension for debugging
1. Load the page you set the breakpoint in; your browser should prompt you to map the file from the webserver to a file in your IDE.
1. The debug stack should appear in your IDE and allow you to step through.
1. Disable the browser extension and refresh the webpage.  The breakpoint should not trip.
1. Verify the presence of `codebase/xdebug.log` 
1. Create `codebase/web/xdebug.php` with the content `<?php xdebug_info();`.  Load the web page, and verify you see the XDebug info screen.
1. Exec (`docker-compose exec drupal /bin/bash`) into the docker container and run `php -v` and insure you see XDebug referenced in the output
1. Run `make dev-down`.  The `.env` file should have `local` as the value for `ENVIRONMENT`, and `docker-compose.yml` should reference the `drupal` image, and not `drupal-dev`

### Enabling PHPStorm debugging
In PHPStorm, click this icon:
![image](https://user-images.githubusercontent.com/146970/110854844-8f36ec00-8283-11eb-9416-cf04242a39f9.png)
Should change to this icon, indicating that it is listening for incoming connections from XDebug.
![image](https://user-images.githubusercontent.com/146970/110854877-9958ea80-8283-11eb-89ea-4528318e988e.png)

### Troubleshooting
XDebug needs to be able to connect to port 9003.  If your break point fails to trip, consult `codebase/xdebug.log`. 

If you don't see `codebase/xdebug.log`, then this PR has an error.

## Further work

This PR needs to be amended with instructions for debugging on the CLI, and debugging services.  But for right now, developers ought to test and verify that step-wise debugging from a browser works.

Also, the CI test needs to be added to insure that a `drupal-dev` image is not mistakenly built or referenced by production.

Full README is included below.



## Debugging

### TL;DR

* Install [browser extension](https://xdebug.org/docs/step_debug#browser-extensions)
* make dev-up
* set breakpoint
* load page, trip breakpoint, repeat
* make dev-down

### Supported Env Vars

|Env Var|Default Value|Description|
|-------|-------------|-----------|
|XDEBUG_CONFIG|n/a|Allows for multiple XDebug config params to be set in a string.  Used for CLI debugging.|
|XDEBUG_SESSION|n/a|Enables XDebug when present.  Used for CLI debugging.|
|XDEBUG_MODE|`develop,debug,trace`|Supported XDebug modes.  Used for browser-based debugging|
|XDEBUG_LOG|`/var/www/drupal/xdebug.log`|XDebug logfile.  Used for browser-based debugging|
|XDEBUG_LOGLEVEL|`7`|XDebug log level. Used for browser-based debuggging.|
|XDEBUG_DISCOVERCLIENTHOST|`false`|If XDebug should attempt to discover the debugging client host.  Used for browser-based debugging.|
|XDEBUG_CLIENTHOST|`host.docker.internal`|The address of the debugging client host.  Used for browser-based debugging.|

## About

Allows a developer to launch Drupal with step-wise debugging enabled.  The three supported use cases are:
* Debugging human-mediated interactions with Drupal (i.e. what most developers would consider to be "debugging")
* Debugging CLI commands (e.g. `drush`) and/or PHP code executed on container startup
* Debugging service-mediate interactions with Drupal

Each use case requires setting a different combination of XDebug settings.  By default, the Drupal development image is configured to support the primary use-case, step-enabled debugging of PHP from a browser.  Enabling all the use cases at once would be counter-productive from a performance standpoint.

Debugging Drupal interactively from a browser requires the installation of an XDebug helper plugin, so if you don't have one installed, you'll need to do so.
* [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/xdebug-helper-for-firefox/)
* [Chrome](https://chrome.google.com/extensions/detail/eadndfjplgieldjbigjakmdgkmoaaaoc)
* [Safari](https://apps.apple.com/app/safari-xdebug-toggle/id1437227804?mt=12)

To run the debugging container:
* Determine which use case applies, and set the environment accordingly in `docker-compose.drupal-dev.yml`.  If you want to debug Drupal with your browser and an IDE, you don't need to change anything.
* Run `make dev-up`

> When your debugging session is over, it is important to remember to run `make dev-down`

In your IDE, configure a PHP/XDebug development session.  Your IDE must listen for debugging requests on port `9003`.  Set a breakpoint.  In your browser, activate the XDebug helper by selecting "Debug", then make a request to Drupal which will activate your breakpoint.  Your browser should prompt you to map the file from the remote server to your local filesystem, and then you can perform step-by-step debugging.

There are a few ways to determine whether you've successfully started the development environment correctly:
* First, `docker ps` should list a running container named `<repo>/drupal-dev:<tag>`, and there should be _no_ other containers named `<repo>/drupal` running.
* Second, create a file named `xdebug.php` in codebase root: `echo "<?php xdebug_info();" > codebase/xdebug.php`, then in your browser visit `https://islandora-idc.traefik.me/xdebug.php`.  Information about XDebug should appear, including its settings.  This is a handy way to double-check XDebug's runtime configuration, especially for more complex debugging scenarios.

> .gitignore is set up to ignore any file that is prefixed with `xdebug`.  If you need to create files to support your debug session, or store output from your debug session, name them `xdebug<something>` to avoid committing debug artifacts.

* A third check, which should be unnecessary, is to `exec` into the `drupal-dev` container and run `php -v`; the output should reference XDebug version 3.

If first two conditions are met, you should be able to start a debug session.  If you can't, then check for the presence of `xdebug.log` in the codebase directory for clues, double check your IDE settings, and check the output of `php -v` in the `drupal-dev` container.  The IDE must accept connections on port `9003`, and XDebug must know the IP address of your machine.  By default, XDebug connects to `host.docker.internal`, which is a special DNS name for the host computer.

To switch back from the debugging container:
* Run `make dev-down`