### PR TITLE
Search facets

### DIFF
--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-23-g9fe79fc
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-223-ga8d6180.1616414495
+SNAPSHOT_TAG=upstream-20201007-739693ae-212-g2539df7.1616703854
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/.env
+++ b/.env
@@ -69,7 +69,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-23-g9fe79fc
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-212-g2539df7.1616703854
+SNAPSHOT_TAG=upstream-20201007-739693ae-213-g3669e99.1616768917
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -6757,12 +6757,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "d1d976f7e87ee1274bee4580f26bd7ba99ad8bfc"
+                "reference": "fba85b02d512ff369183555f5c280a89334dd1a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/d1d976f7e87ee1274bee4580f26bd7ba99ad8bfc",
-                "reference": "d1d976f7e87ee1274bee4580f26bd7ba99ad8bfc",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/fba85b02d512ff369183555f5c280a89334dd1a0",
+                "reference": "fba85b02d512ff369183555f5c280a89334dd1a0",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -6771,7 +6771,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/develop",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-03-24T13:38:56+00:00"
+            "time": "2021-03-25T20:02:53+00:00"
         },
         {
             "name": "jhu-idc/idc_ui_module",

--- a/codebase/config/sync/core.entity_view_display.node.islandora_object.default.yml
+++ b/codebase/config/sync/core.entity_view_display.node.islandora_object.default.yml
@@ -173,7 +173,7 @@ content:
     settings:
       date_separator: dash
       date_order: big_endian
-      month_format: mmmm
+      month_format: mm
       day_format: dd
     third_party_settings: {  }
     type: edtf_default

--- a/codebase/config/sync/core.extension.yml
+++ b/codebase/config/sync/core.extension.yml
@@ -35,6 +35,7 @@ module:
   epp: 0
   eva: 0
   facets: 0
+  facets_rest: 0
   features: 0
   features_ui: 0
   field: 0

--- a/codebase/config/sync/facets.facet.creator.yml
+++ b/codebase/config/sync/facets.facet.creator.yml
@@ -1,0 +1,56 @@
+uuid: c8e9a548-3a01-478f-a33b-97bc0fecfaef
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: creator
+name: Creator
+url_alias: creator
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_creator
+facet_source_id: 'search_api:views_rest__solr_search_content__rest_export_1'
+widget:
+  type: array
+  config:
+    show_numbers: true
+query_operator: and
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/codebase/config/sync/facets.facet.date_created.yml
+++ b/codebase/config/sync/facets.facet.date_created.yml
@@ -1,0 +1,56 @@
+uuid: 636ab79b-e24a-4f20-b1f1-cb127e5f3ecc
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: date_created
+name: Year
+url_alias: date_created
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_date_created
+facet_source_id: 'search_api:views_rest__solr_search_content__rest_export_1'
+widget:
+  type: array
+  config:
+    show_numbers: true
+query_operator: and
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/codebase/config/sync/facets.facet.field_subject.yml
+++ b/codebase/config/sync/facets.facet.field_subject.yml
@@ -1,0 +1,56 @@
+uuid: 92e201d1-0158-4f73-94cd-bd4b3ebc41cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: field_subject
+name: Subject
+url_alias: subject
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_subject
+facet_source_id: 'search_api:views_rest__solr_search_content__rest_export_1'
+widget:
+  type: array
+  config:
+    show_numbers: true
+query_operator: and
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/codebase/config/sync/facets.facet.publisher.yml
+++ b/codebase/config/sync/facets.facet.publisher.yml
@@ -1,0 +1,56 @@
+uuid: c7634359-3a6e-4d18-827f-faaefa45d8ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: publisher
+name: Publisher
+url_alias: publisher
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_publisher
+facet_source_id: 'search_api:views_rest__solr_search_content__rest_export_1'
+widget:
+  type: array
+  config:
+    show_numbers: true
+query_operator: and
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/codebase/config/sync/facets.facet.resource_type.yml
+++ b/codebase/config/sync/facets.facet.resource_type.yml
@@ -1,0 +1,56 @@
+uuid: 657af418-4f84-40f2-a3d0-bb2659e2bd2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: resource_type
+name: 'Resource Type'
+url_alias: resource_type
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: field_resource_type
+facet_source_id: 'search_api:views_rest__solr_search_content__rest_export_1'
+widget:
+  type: array
+  config:
+    show_numbers: true
+query_operator: and
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: true
+processor_configs:
+  active_widget_order:
+    processor_id: active_widget_order
+    weights:
+      sort: 20
+    settings:
+      sort: DESC
+  count_widget_order:
+    processor_id: count_widget_order
+    weights:
+      sort: 30
+    settings:
+      sort: DESC
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/codebase/config/sync/facets.facet_source.search_api__views_rest__solr_search_content__rest_export_1.yml
+++ b/codebase/config/sync/facets.facet_source.search_api__views_rest__solr_search_content__rest_export_1.yml
@@ -1,0 +1,9 @@
+uuid: 07f8710d-4c91-428c-8b07-0b80aaa195fe
+langcode: en
+status: true
+dependencies: {  }
+id: search_api__views_rest__solr_search_content__rest_export_1
+name: 'search_api:views_rest__solr_search_content__rest_export_1'
+filter_key: null
+url_processor: query_string
+breadcrumb: {  }

--- a/codebase/config/sync/search_api.index.default_solr_index.yml
+++ b/codebase/config/sync/search_api.index.default_solr_index.yml
@@ -6,8 +6,8 @@ dependencies:
     - search_api_solr
     - node
     - user
-    - token
     - taxonomy
+    - token
     - content_translation
     - search_api
   config:
@@ -252,11 +252,13 @@ field_settings:
   field_creator:
     label: Creator
     datasource_id: 'entity:node'
-    property_path: field_creator
-    type: integer
+    property_path: 'field_creator:entity:name'
+    type: string
     dependencies:
       config:
         - field.storage.node.field_creator
+      module:
+        - taxonomy
   field_date_available:
     label: 'Date Available'
     datasource_id: 'entity:node'
@@ -293,7 +295,7 @@ field_settings:
     label: 'Digital Publisher'
     datasource_id: 'entity:node'
     property_path: field_digital_publisher
-    type: integer
+    type: string
     dependencies:
       config:
         - field.storage.node.field_digital_publisher
@@ -457,11 +459,13 @@ field_settings:
   field_publisher:
     label: Publisher
     datasource_id: 'entity:node'
-    property_path: field_publisher
-    type: integer
+    property_path: 'field_publisher:entity:name'
+    type: string
     dependencies:
       config:
         - field.storage.node.field_publisher
+      module:
+        - taxonomy
   field_publisher_country:
     label: 'Publisher Country'
     datasource_id: 'entity:node'
@@ -473,11 +477,13 @@ field_settings:
   field_resource_type:
     label: 'Resource Type'
     datasource_id: 'entity:node'
-    property_path: field_resource_type
-    type: integer
+    property_path: 'field_resource_type:entity:name'
+    type: string
     dependencies:
       config:
         - field.storage.node.field_resource_type
+      module:
+        - taxonomy
   field_spatial_coverage:
     label: 'Spatial Coverage'
     datasource_id: 'entity:node'

--- a/codebase/config/sync/views.view.solr_search_content.yml
+++ b/codebase/config/sync/views.view.solr_search_content.yml
@@ -45,9 +45,8 @@ dependencies:
     - search_api.index.default_solr_index
   module:
     - controlled_access_terms
-    - hal
+    - idc_ui_module
     - link
-    - pager_serializer
     - reference_value_pair
     - rest
     - search_api
@@ -1294,10 +1293,11 @@ display:
       display_extenders: {  }
       path: search_rest_endpoint
       style:
-        type: pager_serializer
+        type: idc_serializer
         options:
           formats:
-            hal_json: hal_json
+            json: json
+          show_facets: 1
       row:
         type: data_field
         options:


### PR DESCRIPTION
This introduces search facets that work with the iDC Serializer which combines pagination and facets in results returned by the solr search rest export view.

The changes do involve some config changes mainly around introducing the relevant facets, installing the rest facets module and turning on the iDC serializer that is part of our custom module, making alterations to solr fields as needed and one adjustment to a date field so that it's formatted as other similar date fields are (which affected use of facets).

## Testing this PR

- you'll want to create some content, ideally at least one collection object and several repository items;
- associate the items with the object;
- to test all of the facets you must give the repository items a subject, date created, creator, resource type and publisher (you may need to create taxonomy terms to do this);
- you'll probably want at least a few repository items that have different values for these fields (subject, date created, creator, resource type and publisher) so that you can see the facets eliminating items from the results list;
- visit the collection page;
- notice the facet blocks should be rendered automatically (if you have populated the data as described above);
- click the facet items to turn them on and off again;
- notice the results should change as you toggle facets on/off.

![2021-03-24 10 56 52](https://user-images.githubusercontent.com/6305935/112543401-11e39f00-8d8c-11eb-9639-9bfab736c767.gif)
