### PR TITLE
Provide environment for test execution

### DIFF
--- a/IDC.md
+++ b/IDC.md
@@ -51,6 +51,7 @@ so no need to do anything special other than `make` to invoke them).  A few usef
 * **make snapshot** Create a snapshot of the current Drupal state (db, content files, etc), so that you can reset to this state at will, or push it so that others can.
 * **make snapshot-push** Push the current snapshot image to the container registry
 * **make up** Brings up the development environment, including running `composer install`.
+* **make test** Runs all tests.
 * **make dev-up** Launches the stack with a Drupal image configured with XDebug for IDE-based debugging.  Updates the environment requiring `make dev-down` to be invoked at the conclusion of a development session.
 * **make dev-down** Stops the Drupal development image, and resets the environment to using production.
 
@@ -63,6 +64,23 @@ A few specialized targets are:
   * Has the contents of `codebase` baked into it, as well as all dependencies via `composer install`
   * Will load its config from `config/sync` upon startup
   * Is named `drupal-static` and is tagged based on `git describe --tags`.
+  
+## Running tests
+
+To run all tests, with the environment (configuration, modules, content) reset between each test, run `make test`.  This
+is the make target used to run tests during CI.   To run an individual test, run `make test test=<name of test>`, where `<name of test>` is the name of a test script in the `tests` directory, e.g. `make test test=01-end-to-end.sh`.
+
+When a single test is specified with the `test=` argument, the environment is _not_ reset for the execution of the test.
+That is, the existing configuration, content, and modules present in the current codebase are used.  This is the recommended (and really only supported way) of running your tests while iterating.
+
+Some additional notes about the test execution environment:
+* Tests are run in a subshell given the environment from `.env` and functions from `tests/.includes.sh`.
+  * To share common test-related variables or functions between tests, add them to `tests/.includes.sh`.
+  * Variables added to `.env` are automatically available to the test script.
+* The `test=` argument to `make test` accepts the name of the test suite, minus the `.sh` ending; `make test test=01-end-to-end.sh` and `make test test=01-end-to-end` (no `.sh` extension) will both work.
+* Directly executing the test script (e.g. `cd`ing into `tests` and invoking `./01-end-to-end.sh` on its own) will _no longer work reliably_.
+  * Instead, invoke the test using `make test=<test name>`
+  * This is because test scripts are _provided_ the environment.  If their environment is not properly set up, they won't be able to execute properly.  The test controller (`run-tests.sh`) insures that the test environment is properly set up.
 
 ## Debugging
 

--- a/end-to-end/.testcaferc.json
+++ b/end-to-end/.testcaferc.json
@@ -3,5 +3,6 @@
         "path": "reports/screenshots/",
         "takeOnFails": true,
         "pathPattern": "${FIXTURE}-${TEST}.${DATE}-${TIME}.png"
-      }
+      },
+    "assertionTimeout": 10000
 }

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -188,7 +188,7 @@ static-docker-compose.yml: static-drupal-image
 .SILENT: test
 .PHONY: test
 test:
-	./run-tests.sh
+	./run-tests.sh $(test)
 
 .PHONY: db_dump
 .SILENT: db_dump

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
+#set -vx
 
-if [ -t 1 ] ; then
-	echo "WARNING:  running the test suite will result in resetting the stack's state "
-	echo "to the SNAPSHOT_TAG specified in .env.  This will wipe out all local changes "
-	echo "to Drupal's databases and remove any active content or configuration added since"
-	echo "the last snapshot."
-	echo ""
-	echo "WARNING: continue? [Y/n]"
-	read line; if [ $line != "Y" ]; then echo aborting; exit 1 ; fi
-fi
+warn() {
+    if [ -t 1 ] ; then
+      echo "WARNING:  running the test suite will result in resetting the stack's state "
+      echo "to the SNAPSHOT_TAG specified in .env.  This will wipe out all local changes "
+      echo "to Drupal's databases and remove any active content or configuration added since"
+      echo "the last snapshot."
+      echo ""
+      echo "WARNING: continue? [Y/n]"
+      read line; if [ $line != "Y" ]; then echo aborting; exit 1 ; fi
+  fi
+}
 
 reset() {
 	printf "\nResetting state to last snapshot\n"
@@ -16,18 +19,47 @@ reset() {
 	make -s up 2>/dev/null
 }
 
-for testscript in tests/*.sh; do 
-	reset
-	printf "\n\nRunning ${testscript}\n"
-	{ $testscript && echo "PASS: $testscript"; } || { FAILURES="${FAILURES} $testscript" && echo "FAIL: $testscript";}
-done
+# Execute the specified test in a subshell, provided the contents of .env as its environment and tests/.funcs.sh for
+# common shell functions
+execute() {
+  local testscript="$1"
 
-reset
+  if [ ! -f "${testscript}" ] ; then
+    origtestscript="${testscript}"
+    testscript="${testscript}.sh"
+  fi
+
+  if [ ! -f "${testscript}" ] ; then
+    echo "Checked for the presence of ${origtestscript} and ${testscript}, but neither existed."
+    echo "exiting"
+    exit 1
+  fi
+
+  bash -c "set -a && \
+           sed -e 's/^REQUIRED_SERIVCES=\(.*\)/REQUIRED_SERIVCES="\1"/' < .env > /tmp/test-env && \
+           source /tmp/test-env && \
+           source tests/.includes.sh && \
+           ${testscript}" || { FAILURES="${FAILURES} $testscript" && echo "FAIL: $testscript"; }
+}
+
+# If a test is specified, execute it using the existing state, otherwise run all tests, resetting the state for each
+if [ -n "$1" ] ; then
+  testscript="$1"
+  printf "\n\nRunning ${testscript} using the current Drupal state (i.e. no reset of the environment will occur)\n"
+  execute tests/${testscript}
+else
+  warn
+  for testscript in tests/*.sh; do
+    reset
+    printf "\n\nRunning ${testscript}\n"
+    execute ${testscript}
+  done
+  reset
+fi
 
 if [ ! -z "${FAILURES}" ] ; then
 	printf "\nFAIL: ${FAILURES}\n"
 	exit 1
 fi
-
 
 printf "\nSUCCESS: All test passed\n"

--- a/tests/.includes.sh
+++ b/tests/.includes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#
+# Shell functions and environment common to all tests go here
+#
+
+# The name of the currently running Drupal Docker container
+DRUPAL_CONTAINER_NAME=$(docker ps | awk '{print $NF}'|grep drupal)
+
+# The Docker registry used to obtain the migration assets image
+assets_repo=${MIGRATION_ASSETS_REPO:-ghcr.io/jhu-sheridan-libraries/idc-isle-dc}
+# The name of the Docker image for migration assets
+assets_image=${MIGRATION_ASSETS_IMAGE:-migration-assets}
+# The migration assets image tag
+assets_image_tag=${MIGRATION_ASSETS_IMAGE_TAG:-088c482.1617637226}
+# The *external* port the migration assets HTTP server listens on
+ext_assets_port=${MIGRATION_ASSETS_PORT:-8081}
+# The name used by the migration assets container
+assets_container=${MIGRATION_ASSETS_CONTAINER:-migration-assets}
+
+# Starts the assets container used for migrations
+function startMigrationAssetsContainer {
+  docker run --name ${assets_container} --network gateway --rm -d ${assets_repo}/${assets_image}:${assets_image_tag}
+  trap "docker stop ${assets_container}" EXIT
+}

--- a/tests/01-end-to-end.sh
+++ b/tests/01-end-to-end.sh
@@ -1,2 +1,7 @@
 #!/bin/sh
-docker-compose exec -T testcafe npm test
+
+if [ -t 1 ] ; then
+  docker-compose exec -T testcafe npm test
+else
+  docker-compose exec -ti testcafe npm test
+fi

--- a/tests/10-migration-backend-tests.sh
+++ b/tests/10-migration-backend-tests.sh
@@ -1,54 +1,21 @@
 #!/bin/bash
 set -e
 
-BASE_TEST_FOLDER=10-migration-backend-tests
-DRUPAL_CONTAINER_NAME=$(docker ps | awk '{print $NF}'|grep drupal)
-CURRENT_DIR=$(pwd)
-
-# The Docker registry used to obtain the migration assets image
-assets_repo=${MIGRATION_ASSETS_REPO:-ghcr.io/jhu-sheridan-libraries/idc-isle-dc}
-# The name of the Docker image for migration assets
-assets_image=${MIGRATION_ASSETS_IMAGE:-migration-assets}
-# The migration assets image tag
-assets_image_tag=${MIGRATION_ASSETS_IMAGE_TAG:-088c482.1617637226}
-# The *external* port the migration assets HTTP server listens on
-ext_assets_port=${MIGRATION_ASSETS_PORT:-8081}
-# The name used by the migration assets container
-assets_container=${MIGRATION_ASSETS_CONTAINER:-migration-assets}
-
-# Locate test directory
-if [ ! -d ${BASE_TEST_FOLDER} ] ;
-then
-  BASE_TEST_FOLDER=tests/${BASE_TEST_FOLDER}
-  if [ ! -d ${BASE_TEST_FOLDER} ] ;
-  then
-    echo "Missing expected test directory ${BASE_TEST_FOLDER}"
-    exit 1
-  else
-    cd ${BASE_TEST_FOLDER}
-  fi
-else
-  cd ${BASE_TEST_FOLDER}
-fi
-
-TESTCAFE_TESTS_FOLDER=$(pwd)/testcafe
+BASE_TEST_FOLDER="$(pwd)/$(dirname $0)/$(basename $0 .sh)"
+TESTCAFE_TESTS_FOLDER="$BASE_TEST_FOLDER/testcafe"
 
 # Start the backend that serves the media files to be migrated
 # Listens internally on port 80 (addressed as http://<assets_container>/assets/)
-docker run --name ${assets_container} --network gateway --rm -d ${assets_repo}/${assets_image}:${assets_image_tag}
-trap "docker stop ${assets_container}" EXIT
+startMigrationAssetsContainer
 
 # Execute migrations using testcafe
 docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js
 
 # Verify migrations using go
 # Build docker image (TODO: should it be defined in docker-compose.yml to avoid any env issues?)
-docker build -t local/migration-backend-tests ./verification
+docker build -t local/migration-backend-tests "${BASE_TEST_FOLDER}/verification"
 
 # Execute tests in docker image, on the same docker network (gateway, idc_default?) as Drupal
 # TODO: expose logs when failing tests?
 # N.B. trailing slash on the BASE_ASSETS_URL is important.  uses the internal URL.
 docker run --network gateway --rm -e BASE_ASSETS_URL=http://${assets_container}/assets/ local/migration-backend-tests
-
-# Back to parent directory
-cd ${CURRENT_DIR}

--- a/tests/11-file-deletion-tests.sh
+++ b/tests/11-file-deletion-tests.sh
@@ -1,45 +1,11 @@
 #!/bin/bash
 set -e
 
-BASE_TEST_FOLDER=11-file-deletion-tests
-DRUPAL_CONTAINER_NAME=$(docker ps | awk '{print $NF}'|grep drupal)
-CURRENT_DIR=$(pwd)
-
-# The Docker registry used to obtain the migration assets image
-assets_repo=${MIGRATION_ASSETS_REPO:-ghcr.io/jhu-sheridan-libraries/idc-isle-dc}
-# The name of the Docker image for migration assets
-assets_image=${MIGRATION_ASSETS_IMAGE:-migration-assets}
-# The migration assets image tag
-assets_image_tag=${MIGRATION_ASSETS_IMAGE_TAG:-088c482.1617637226}
-# The *external* port the migration assets HTTP server listens on
-ext_assets_port=${MIGRATION_ASSETS_PORT:-8081}
-# The name used by the migration assets container
-assets_container=${MIGRATION_ASSETS_CONTAINER:-migration-assets}
-
-# Locate test directory
-if [ ! -d ${BASE_TEST_FOLDER} ] ;
-then
-  BASE_TEST_FOLDER=tests/${BASE_TEST_FOLDER}
-  if [ ! -d ${BASE_TEST_FOLDER} ] ;
-  then
-    echo "Missing expected test directory ${BASE_TEST_FOLDER}"
-    exit 1
-  else
-    cd ${BASE_TEST_FOLDER}
-  fi
-else
-  cd ${BASE_TEST_FOLDER}
-fi
-
-TESTCAFE_TESTS_FOLDER=$(pwd)/testcafe
+TESTCAFE_TESTS_FOLDER="$(pwd)/$(dirname $0)/$(basename $0 .sh)/testcafe"
 
 # Start the backend that serves the media files to be migrated
 # Listens internally on port 80 (addressed as http://<assets_container>/assets/)
-docker run --name ${assets_container} --network gateway --rm -d ${assets_repo}/${assets_image}:${assets_image_tag}
-trap "docker stop ${assets_container}" EXIT
+startMigrationAssetsContainer
 
 # Execute migrations using testcafe
 docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js
-
-# Back to parent directory
-cd ${CURRENT_DIR}

--- a/tests/12-migration-derivative-tests.sh
+++ b/tests/12-migration-derivative-tests.sh
@@ -1,45 +1,11 @@
 #!/bin/bash
 set -e
 
-BASE_TEST_FOLDER=12-migration-derivative-tests
-DRUPAL_CONTAINER_NAME=$(docker ps | awk '{print $NF}'|grep drupal)
-CURRENT_DIR=$(pwd)
-
-# The Docker registry used to obtain the migration assets image
-assets_repo=${MIGRATION_ASSETS_REPO:-ghcr.io/jhu-sheridan-libraries/idc-isle-dc}
-# The name of the Docker image for migration assets
-assets_image=${MIGRATION_ASSETS_IMAGE:-migration-assets}
-# The migration assets image tag
-assets_image_tag=${MIGRATION_ASSETS_IMAGE_TAG:-088c482.1617637226}
-# The *external* port the migration assets HTTP server listens on
-ext_assets_port=${MIGRATION_ASSETS_PORT:-8081}
-# The name used by the migration assets container
-assets_container=${MIGRATION_ASSETS_CONTAINER:-migration-assets}
-
-# Locate test directory
-if [ ! -d ${BASE_TEST_FOLDER} ] ;
-then
-  BASE_TEST_FOLDER=tests/${BASE_TEST_FOLDER}
-  if [ ! -d ${BASE_TEST_FOLDER} ] ;
-  then
-    echo "Missing expected test directory ${BASE_TEST_FOLDER}"
-    exit 1
-  else
-    cd ${BASE_TEST_FOLDER}
-  fi
-else
-  cd ${BASE_TEST_FOLDER}
-fi
-
-TESTCAFE_TESTS_FOLDER=$(pwd)/testcafe
+TESTCAFE_TESTS_FOLDER="$(pwd)/$(dirname $0)/$(basename $0 .sh)/testcafe"
 
 # Start the backend that serves the media files to be migrated
 # Listens internally on port 80 (addressed as http://<assets_container>/assets/)
-docker run --name ${assets_container} --network gateway --rm -d ${assets_repo}/${assets_image}:${assets_image_tag}
-trap "docker stop ${assets_container}" EXIT
+startMigrationAssetsContainer
 
 # Execute migrations using testcafe
 docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js
-
-# Back to parent directory
-cd ${CURRENT_DIR}


### PR DESCRIPTION
## Summary

Provides each test script with an environment comprised of the contents of `.env` and `tests/.includes.sh`.

> ~~This PR will need to be rebased before it is merged, as it updates some of the tests used by the media migration PR.  Only the last three commits require review.~~

Currently there is no supported means of sharing environment variables or functions between test shell scripts, nor is there any supported means of examining or using the contents of `.env` from the test shell scripts.  This PR provides both.

* Variables or functions meant to be shared between test scripts can be added to `tests/.includes.sh`
* Any variable defined in `.env` is automatically present in the test shell script environment

Test shell scripts to not need to manually parse `.env`, nor do they need to duplicate boilerplate functions or test-related environment variables.

A tradeoff is that individual test scripts can no longer be reliably executed individually (e.g. `cd`ing into `tests` and invoking `10-migration-backend-tests.sh` will no longer work).  Individual tests must be invoked using `make test test=<name of test>`.

## Details

The `make test` target functions just as before, running all test scripts in the `tests/` directory, and resetting the environment between each test.

This PR allows for a single test to be executed, using `make test test=<name of test>` where `<name of test>` is the name of the shell script in the `tests/` directory: e.g. `make test test=10-migration-backend-tests.sh`.  This is now the supported way of invoking individual test scripts.

When a single test is executed using `make test test=<name of test>`, the environment is _not_ reset at all, making this form of test execution the ideal way to iterate on a test.

As an aside, this PR increases the timeouts used by testcafe when waiting for async functions to execute.  After running the CI jobs a few times, it seems that increasing the timeout values work.


