### PR TITLE
Parameterization of entity lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ codebase/web/modules/contrib/
 codebase/web/themes/contrib/
 snapshot/data.tar
 xdebug*
+*.orig
+*.rej
 
 # =========================
 # Packages
@@ -103,6 +105,4 @@ certs
 # Ignore node and test stuff
 *node_modules
 end-to-end/reports
-tests/10-migration-backend-tests/testcafe/screenshots
-tests/11-file-deletion-tests/testcafe/screenshots
-tests/12-migration-derivative-tests/testcafe/screenshots
+screenshots/

--- a/Makefile
+++ b/Makefile
@@ -178,14 +178,14 @@ hydrate: update-settings-php update-config-from-environment solr-cores namespace
 .PHONY: delete-shortcut-entities
 .SILENT: delete-shortcut-entities
 delete-shortcut-entities:
-	docker-compose exec drupal drush -l $(SITE) entity:delete shortcut_set
+	docker-compose exec -T drupal drush -l $(SITE) entity:delete shortcut_set
 
 # Forces the site uuid to match that in the config_sync_directory so that
 # configuration can be imported.
 .PHONY: set-site-uuid
 .SILENT: set-site-uuid
 set-site-uuid:
-	docker-compose exec drupal with-contenv bash -lc "set_site_uuid"
+	docker-compose exec -T drupal with-contenv bash -lc "set_site_uuid"
 
 # RemovesForces the site uuid to match that in the config_sync_directory so that
 # configuration can be imported.
@@ -205,7 +205,7 @@ config-export:
 .PHONY: config-import
 .SILENT: config-import
 config-import: set-site-uuid delete-shortcut-entities
-	docker-compose exec drupal drush -l $(SITE) config:import -y
+	docker-compose exec -T drupal drush -l $(SITE) config:import -y
 
 # Dump database.
 database-dump:

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8f6b98d239668593d5e31bed7a1f9f8",
+    "content-hash": "8ab2da6672372c8e4753f47830716bc0",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7290,23 +7290,24 @@
         },
         {
             "name": "jhu_idc/idc_migration",
-            "version": "v1.0.2",
+            "version": "v1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_migration.git",
-                "reference": "e878fe4e629b0aaeee8d89548ef4f8757ab7e422"
+                "reference": "86f5ae598c1d611c16f42d4f64f89a470fc84479"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_migration/zipball/e878fe4e629b0aaeee8d89548ef4f8757ab7e422",
-                "reference": "e878fe4e629b0aaeee8d89548ef4f8757ab7e422",
+                "url": "https://api.github.com/repos/jhu-idc/idc_migration/zipball/86f5ae598c1d611c16f42d4f64f89a470fc84479",
+                "reference": "86f5ae598c1d611c16f42d4f64f89a470fc84479",
                 "shasum": ""
             },
             "require": {
-                "drupal/core": "^8.8.1",
+                "drupal/core": "8.9.13",
                 "php": ">=7.3"
             },
             "require-dev": {
+                "drupal/migrate_plus": "5.1.0",
                 "phpunit/phpunit": "^7.5"
             },
             "type": "drupal-module",
@@ -7328,9 +7329,9 @@
             ],
             "description": "Custom migration plugins for IDC",
             "support": {
-                "source": "https://github.com/jhu-idc/idc_migration/tree/v1.0.2"
+                "source": "https://github.com/jhu-idc/idc_migration/tree/v1.0.3"
             },
-            "time": "2021-03-19T15:39:24+00:00"
+            "time": "2021-04-26T20:16:18+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -18,7 +18,7 @@ bootstrap: snapshot-empty default destroy-state up install \
 .SILENT: cache-rebuild
 cache-rebuild:
 	echo "rebuilding Drupal cache..."
-	docker-compose exec drupal drush cr -y
+	docker-compose exec -T drupal drush cr -y
 
 .PHONY: destroy-state
 .SILENT: destroy-state

--- a/tests/13-migration-entity-resolution.sh
+++ b/tests/13-migration-entity-resolution.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+TEST_DIR="$(pwd)/$(dirname $0)/$(basename $0 .sh)"
+TESTCAFE_TESTS_FOLDER="${TEST_DIR}/testcafe"
+
+# Patch config to use parse_entity_lookup, ignore if previously applied
+# TODO: this should be removed after the development branch configuration is updated to use the parse_entity_lookup plugin
+patch -p1 -N < "${TEST_DIR}/config.patch" && make config-import
+
+# Execute migrations using testcafe
+docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --dev --selector-timeout 120000 --page-load-timeout 120000 --assertion-timeout 120000 --ajax-request-timeout 120000 --page-request-timeout 120000 --browser-init-timeout 120000 --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js

--- a/tests/13-migration-entity-resolution.sh
+++ b/tests/13-migration-entity-resolution.sh
@@ -5,8 +5,20 @@ TEST_DIR="$(pwd)/$(dirname $0)/$(basename $0 .sh)"
 TESTCAFE_TESTS_FOLDER="${TEST_DIR}/testcafe"
 
 # Patch config to use parse_entity_lookup, ignore if previously applied
+# Accommodate the use of the static image in CI
 # TODO: this should be removed after the development branch configuration is updated to use the parse_entity_lookup plugin
-patch -p1 -N < "${TEST_DIR}/config.patch" && make config-import
+STATIC=`cat docker-compose.yml | grep DRUPAL_INSTANCE | grep static | wc -l`
+if [ $STATIC -lt 1 ]; then
+  patch -p1 -N < "${TEST_DIR}/config.patch"
+  trap "git checkout -- codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml" EXIT
+else
+  docker cp "${TEST_DIR}/config.patch" "${DRUPAL_CONTAINER_NAME}:/var/www/drupal"
+  docker-compose exec -T drupal /bin/bash -c 'cat ./config.patch | patch --verbose -p 2'
+fi
+make config-import cache-rebuild
+
+# Make sure a screenshots directory is available
+mkdir "${TESTCAFE_TESTS_FOLDER}/screenshots" && chmod 777 "${TESTCAFE_TESTS_FOLDER}/screenshots"
 
 # Execute migrations using testcafe
-docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --dev --selector-timeout 120000 --page-load-timeout 120000 --assertion-timeout 120000 --ajax-request-timeout 120000 --page-request-timeout 120000 --browser-init-timeout 120000 --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js
+docker run --network gateway -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.js

--- a/tests/13-migration-entity-resolution/config.patch
+++ b/tests/13-migration-entity-resolution/config.patch
@@ -1,0 +1,39 @@
+diff --git a/codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml b/codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml
+index 5c6d4d82..040d625d 100644
+--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml
++++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml
+@@ -408,9 +408,12 @@ process:
+       delimiter: '|'
+       strict: false
+     -
+-      plugin: migration_lookup
+-      migration: idc_ingest_new_collection
+-      no_stub: true
++      plugin: parse_entity_lookup
++      defaults:
++        entity_type: node
++        bundle: collection_object
++        bundle_key: type
++        value_key: title
+   field_model:
+     plugin: entity_lookup
+     bundle_key: vid
+@@ -497,11 +500,13 @@ process:
+       delimiter: '|'
+       strict: false
+     -
+-      plugin: entity_lookup
+-      bundle_key: vid
+-      bundle: subject
+-      entity_type: taxonomy_term
+-      value_key: name
++      plugin: parse_entity_lookup
++      delimiter: ':'
++      defaults:
++        entity_type: taxonomy_term
++        bundle: subject
++        bundle_key: vid
++        value_key: name
+   field_table_of_contents:
+     -
+       plugin: skip_on_empty

--- a/tests/13-migration-entity-resolution/testcafe/entity_resolution.spec.js
+++ b/tests/13-migration-entity-resolution/testcafe/entity_resolution.spec.js
@@ -1,0 +1,53 @@
+import {Selector} from 'testcafe';
+import {adminUser} from "./roles";
+
+const migrate_person_taxonomy = 'idc_ingest_taxonomy_persons';
+const migrate_geolocation_taxonomy = 'idc_ingest_taxonomy_geolocation';
+const migrate_new_items = 'idc_ingest_new_items';
+const migrate_new_collection = 'idc_ingest_new_collection';
+const migrate_subject_taxonomy = 'idc_ingest_taxonomy_subject';
+const migrate_corporatebody_taxonomy = 'idc_ingest_taxonomy_corporatebody';
+
+const selectMigration = Selector('#edit-migrations');
+const migrationOptions = selectMigration.find('option');
+
+async function migrate(t, id, sourcefile) {
+  await t
+    .click(selectMigration)
+    .click(migrationOptions.withAttribute('value', id));
+
+  await t
+    .setFilesToUpload('#edit-source-file', [
+      sourcefile
+    ])
+    .click('#edit-import');
+}
+
+fixture`Migration Entity Resolution`
+  .page`https://islandora-idc.traefik.me/migrate_source_ui`
+  .beforeEach(async t => {
+    await t
+      .useRole(adminUser);
+  });
+
+test('Perform Entity Resolution Migrations', async t => {
+  await migrate(t, migrate_person_taxonomy, './migrations/islandora_object-persons.csv')
+  await migrate(t, migrate_geolocation_taxonomy, './migrations/islandora_object-geolocations.csv')
+  await migrate(t, migrate_corporatebody_taxonomy, './migrations/islandora_object-corporatebodies.csv')
+  await migrate(t, migrate_subject_taxonomy, './migrations/islandora_object-subjects.csv')
+  await migrate(t, migrate_new_collection, './migrations/islandora_object-collections.csv')
+  await migrate(t, migrate_new_items, './migrations/islandora_object.csv')
+
+  let contentListing = 'https://islandora-idc.traefik.me/admin/content'
+
+  await t.navigateTo(contentListing);
+  const islandora_obj = Selector('div.view-content').find('a').withText('Sample Repository Item');
+  await t.expect(islandora_obj.count).eql(1);
+  await t.click(islandora_obj);
+
+  const subj = Selector('div.node__content').find('a').withText('My Subject');
+  await t.expect(subj.count).eql(1)
+
+  const member_of = Selector('div.node__content').find('a').withText('Images Collection');
+  await t.expect(member_of.count).eql(1)
+});

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-collections.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-collections.csv
@@ -1,0 +1,2 @@
+local_id,title,title_language,description
+io-collection-01,Images Collection,eng,Test Collection;eng

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-corporatebodies.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-corporatebodies.csv
@@ -1,0 +1,2 @@
+local_id,name,description
+io-corp_01,My Corporate Body,<p>A Corporate Body term for testing</p>

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-geolocations.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-geolocations.csv
@@ -1,0 +1,2 @@
+local_id,name,description
+io-geolocation-01,My GeoLocation,A GeoLocation taxonomy term for testing

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-persons.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-persons.csv
@@ -1,0 +1,2 @@
+local_id,name,description
+io-person_1,My Person,A Person taxonomy term for testing

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-subjects.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object-subjects.csv
@@ -1,0 +1,2 @@
+local_id,name,description
+io-subject-01,My Subject,A Subject taxonomy term for testing

--- a/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object.csv
+++ b/tests/13-migration-entity-resolution/testcafe/migrations/islandora_object.csv
@@ -1,0 +1,2 @@
+local_id,title,description,member_of,subject
+io_01,Sample Repository Item,Test repository object;eng,::title:Images Collection,::name:My Subject

--- a/tests/13-migration-entity-resolution/testcafe/roles.js
+++ b/tests/13-migration-entity-resolution/testcafe/roles.js
@@ -1,0 +1,11 @@
+import { Role } from 'testcafe';
+
+/**
+ * Drupal administrator via local login
+ */
+export const adminUser = Role('https://islandora-idc.traefik.me/user/login', async t => {
+    await t
+        .typeText('#edit-name', 'admin')
+        .typeText('#edit-pass', 'password')
+        .click('#edit-submit');
+});


### PR DESCRIPTION
## About
This PR introduces a novel plugin, `parse_entity_lookup`, which is used to parameterize an instance of `entity_lookup` using structured values from a source spreadsheet.  It implements the "lookup convention" that was [discussed](https://docs.google.com/document/d/1WCu8bRtLELgGGoIBuyed0-pJB1GwgPuuGeLnMbCOaMM/edit#heading=h.dwao6437w2vq), [proposed](https://github.com/jhu-idc/iDC-general/issues/316) and assigned in [#317](https://github.com/jhu-idc/iDC-general/issues/317).

Example configuration for the `parse_entity_lookup` plugin is below, but refer to the [PHPdoc](https://github.com/jhu-idc/idc_migration/blob/master/src/Plugin/migrate/process/ParseEntityLookup.php) for full usage:

```
plugin: parse_entity_lookup
  source: subject
  delimiter: ':'
  defaults:
    entity_type: taxonomy_term
    bundle_key: vid
    bundle: subject
    value_key: name
```

Values in the source spreadsheet must be formatted for use by the plugin: `<entity_type>:<bundle>:<value_key>:<value>`.  For example, the `subject` field in the spreadsheet would carry a value `:::History`.  If the author of the spreadsheet wished to resolve an entity reference to a different taxonomy, they could adjust the value to be `:Foo Taxonomy::Some Value`.  

Default values from the plugin configuration will be used where they are elided from the spreadsheet.

Note that the `bundle_key` is _not ever_ read from the spreadsheet, so it must be supplied in the `defaults` section of the plugin configuration (i.e. it is a required field).  This means that the user not be able to reference different entity types unless the the `bundle_key` of the types happens to be the same.

## To test
* `make reset`
* Run the the `13-migration-entity-resolution` test (`make test test=13-migration-entity-resolution`) and see if it passes.
* Refer to the migrations used for the `13-migration-entity-resolution` test, specifically `islandora_object.csv` and note the formatting used for the `member_of` and `subject` fields.
* Navigate to the Sample Islandora Object in Drupal, and note that it is a member of a Collection and has a Subject.

The test demonstrates that the `parse_entity_plugin` can be used in lieu of the `entity_lookup` plugin but it does not update the production migration configuration, since there are anticipated changes to migration configuration that may conflict from incoming PRs.

If the automated test isn't enough for you, feel free to modify the Islandora Object migration definition located in `codebase/config/sync/migrate_plus.migration.idc_ingest_new_items.yml`.

* Find a field that uses the `entity_lookup` plugin, e.g. `field_title_language`, and modify the field to use the `parse_entity_plugin`.  Do _not_ edit the configuration for `field_member_of` or `field_subject`.
* Edit the `islandora_object.csv` migration for the `13-migration-entity-resolution` test, and update it to contain the properly-formatted source value.
* Import your updated configuration `make config-import`
* Re-run the test.  Note the test patches the configuration, so if the patch conflicts with your changes you'll need to manually edit `13-migration-entity-resolution.sh` and comment out the patch operation.  

 