### PR TITLE
Fix snapshot and exported configuration

### DIFF
--- a/.env
+++ b/.env
@@ -73,7 +73,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-26-g09f74e4
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-268-gad208e91.1620145189
+SNAPSHOT_TAG=upstream-20201007-739693ae-271-gffd34ff6.1621449833
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/field.storage.media.field_file_size.yml
+++ b/codebase/config/sync/field.storage.media.field_file_size.yml
@@ -14,8 +14,8 @@ field_name: field_file_size
 entity_type: media
 type: integer
 settings:
-  unsigned: false
-  size: normal
+  unsigned: true
+  size: big
 module: core
 locked: false
 cardinality: 1


### PR DESCRIPTION
This PR introduces/fixes a database schema update that was provided by the `islandora_core_feature` module which modifies the type of the `media__field_file_size.field_file_size_value` to an unsigned `bigint`.  Snapshots leading up to this PR do not fully incorporate the update (they were corrupted by some unknown mechanism, but certainly by human error - since humans are the only beings making snapshots to this point).

"Not fully incorporating" the update manifests as 
* the "high water mark" for the `islandora_core_feature` update hook being correct, present in the database as `i:8001;`
* however, the actual update itself has has _not_ been run - `media__field_file_size.field_file_size_value` is typed as a signed `int`
* the external configuration for the field in `codebase/config/sync/field.storage.media.field_file_size.yml` describes it as a signed integer

This PR corrects the latter two bullet points by:
1. Running the update hook `islandora_core_feature_update_8001` from `islandora_core_feature`
1. Exporting the configuration for `field.storage.media.field_file_size` to `config/sync`
1. Creating and pushing a new snapshot

To test this PR:
1. After checking out this PR, run `make reset`
1. Verify the type of the `media__field_file_size.field_file_size_value` as an unsigned `bigint` in _active_ configuration
    1. `select data_type, column_type from information_schema.columns where table_name = 'media__field_file_size' and column_name = 'field_file_size_value';`
1. Verify the high water mark of `islandora_core_feature` as `i:8001;`
    1. `select value from key_value where collection = 'system.schema' AND name = 'islandora_core_feature';`
1. Verify the _external_ configuration`codebase/config/sync/field.storage.media.field_file_size.yml` describes `media__field_file_size.field_file_size_value` as an unsigned big integer

References for posterity:
* https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_update_N/8.2.x
* https://www.drupal.org/node/2535316
* `update_get_update_list` function in `web/core/includes/update.inc`
* To re-run the hook, set the value of `system.schema` for `islandora_core_feature` to the "zero" value of `i:8000;` and restart Drupal.
    * `update key_value set value = 'i:8000;' where collection = 'system.schema' AND name = 'islandora_core_feature'`