### PR TITLE
Makes cantaloupe URL configurable

### DIFF
--- a/codebase/config/sync/islandora_iiif.settings.yml
+++ b/codebase/config/sync/islandora_iiif.settings.yml
@@ -1,3 +1,3 @@
-iiif_server: 'https://islandora-idc.traefik.me/cantaloupe/iiif/2'
+iiif_server: 'env:DRUPAL_DEFAULT_CANTALOUPE_URL'
 _core:
   default_config_hash: NCzOnzkSw_H5SbPJb-EOzzJby1pQ8JI6IzZJckM7WOU

--- a/codebase/config/sync/openseadragon.settings.yml
+++ b/codebase/config/sync/openseadragon.settings.yml
@@ -122,5 +122,5 @@ default_options:
   tileSize: 256
 _core:
   default_config_hash: e3vGYyreIdWCpI2ILIqc_JoZuzRL3bl9zjZvnMeuy7I
-iiif_server: 'https://islandora-idc.traefik.me/cantaloupe/iiif/2'
+iiif_server: 'env:DRUPAL_DEFAULT_CANTALOUPE_URL'
 manifest_view: iiif_manifest

--- a/codebase/web/sites/default/settings.local.php
+++ b/codebase/web/sites/default/settings.local.php
@@ -29,6 +29,8 @@ $config['s3fs.settings']['hostname'] = getenv('DRUPAL_DEFAULT_S3_HOSTNAME');
 $config['s3fs.settings']['use_cname'] = (bool) getenv('DRUPAL_DEFAULT_S3_USE_CNAME') ?: false;
 $config['s3fs.settings']['use_customhost'] = (bool) getenv('DRUPAL_DEFAULT_S3_USE_CUSTOMHOST') ?: false;
 $config['s3fs.settings']['use_path_style_endpoint'] = (bool) getenv('DRUPAL_DEFAULT_S3_USE_PATH_STYLE_ENDPOINT') ?: false;
+$config['islandora_iiif.settings']['iiif_server'] = getenv('DRUPAL_DEFAULT_CANTALOUPE_URL');
+$config['openseadragon.settings']['iiif_server'] = getenv('DRUPAL_DEFAULT_CANTALOUPE_URL');
 
 # This will be overridden by s3fs, but needs a value in order to enable private FS at all. 
 $settings['file_private_path'] = '/tmp'; 


### PR DESCRIPTION
`DRUPAL_DEFAULT_CANTALOUPE_URL` is one of those ISLE environment variables that _should_ change the cantaloupe URL, but doesn't (i.e. it may have effect only upon an initial install).

This PR adds `DRUPAL_DEFAULT_CANTALOUPE_URL` to the config overrides in `settings.local.php`, and updates the values in `config/sync` to bogus values, thus forcing the user to define a  `DRUPAL_DEFAULT_CANTALOUPE_URL` that overrides these bogus defaults.  _these bogus values ***are*** intended to be committed to config/sync.  The point is to make sure things break in an obvious way if `DRUPAL_DEFAULT_CANTALOUPE_URL` is not set_

Note:  I'm not including a snapshot in the PR, as it is unnecessary to do so.

# To test
* `make reset`
* Do `make config-import` to pull in the bogus openseadragon URLs
* If you want, look in the [configuration UI](https://islandora-idc.traefik.me/admin/config/islandora/iiif) and verify that a bogus value of `env:DRUPAL_DEFAULT_CANTALOUPE_URL` is present.
* Add a new repository item (fill in the annoying required fields), make sure it's an `Image` model, and make sure the openseadragon hint is checked.  
* Once the repository item is created, add new image media.  Make sure to check `original file` so that derivatives are generated.
* Navigate to the repository item's page (e.g. /node/XYZ),  You should see the openseadragon viewer.  After a delay, you'll see the image pop up in the viewer.  This verifies that Drupal is using the overriden config rather than the bogus values imported.




Resolves jhu-idc/idc-general#336