### PR TITLE
Advanced search and media viewers

### DIFF
--- a/.env
+++ b/.env
@@ -73,7 +73,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-27-g6cd914d
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-283-gdf0e618.1621515867
+SNAPSHOT_TAG=upstream-20201007-739693ae-274-g98ac913.1621609395
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -7583,12 +7583,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "84246c27ac87bb5d92581acc6f4ddee268c8b0cc"
+                "reference": "071a1b4a36948212ff154e58b944c07c3048f59e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/84246c27ac87bb5d92581acc6f4ddee268c8b0cc",
-                "reference": "84246c27ac87bb5d92581acc6f4ddee268c8b0cc",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/071a1b4a36948212ff154e58b944c07c3048f59e",
+                "reference": "071a1b4a36948212ff154e58b944c07c3048f59e",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -7597,7 +7597,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/develop",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-05-17T20:53:00+00:00"
+            "time": "2021-05-21T13:58:03+00:00"
         },
         {
             "name": "jhu-idc/idc_ui_module",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -7583,12 +7583,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "3e46bfa35f815ca4a16375911e0fa4b8818e710e"
+                "reference": "84246c27ac87bb5d92581acc6f4ddee268c8b0cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/3e46bfa35f815ca4a16375911e0fa4b8818e710e",
-                "reference": "3e46bfa35f815ca4a16375911e0fa4b8818e710e",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/84246c27ac87bb5d92581acc6f4ddee268c8b0cc",
+                "reference": "84246c27ac87bb5d92581acc6f4ddee268c8b0cc",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -7597,7 +7597,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/develop",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-04-12T19:47:17+00:00"
+            "time": "2021-05-17T20:53:00+00:00"
         },
         {
             "name": "jhu-idc/idc_ui_module",
@@ -7605,12 +7605,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "a554904de72e51b516fb7194c412fec51af47e54"
+                "reference": "aa0037b451499d2ba8135141892b0e83631f16a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/a554904de72e51b516fb7194c412fec51af47e54",
-                "reference": "a554904de72e51b516fb7194c412fec51af47e54",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/aa0037b451499d2ba8135141892b0e83631f16a6",
+                "reference": "aa0037b451499d2ba8135141892b0e83631f16a6",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -7619,7 +7619,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2021-04-12T19:29:48+00:00"
+            "time": "2021-05-19T18:36:02+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",

--- a/codebase/config/sync/context.context.openseadragon_block.yml
+++ b/codebase/config/sync/context.context.openseadragon_block.yml
@@ -54,6 +54,21 @@ reactions:
         context_id: openseadragon_block
         uuid: 16401a13-1031-4ffe-96b2-5909df309f6a
         custom_id: openseadragon_block
+      54fb68cd-6165-447b-978b-d56f0869117a:
+        id: openseadragon_block
+        label: 'Openseadragon block'
+        provider: openseadragon
+        label_display: '0'
+        region: content
+        weight: '0'
+        iiif_manifest_url: '/node/[node:nid]/manifest'
+        context_mapping: {  }
+        custom_id: openseadragon_block
+        theme: idcui
+        css_class: ''
+        unique: 0
+        context_id: openseadragon_block
+        uuid: 54fb68cd-6165-447b-978b-d56f0869117a
     id: blocks
     saved: false
     uuid: 50b9b25e-0836-4531-8a78-9698d71d81de

--- a/codebase/config/sync/pdf.settings.yml
+++ b/codebase/config/sync/pdf.settings.yml
@@ -1,0 +1,1 @@
+custom_viewer: /themes/contrib/idc-ui-theme/js/packages/pdf.js/web/viewer.html

--- a/codebase/config/sync/views.view.iiif_manifest.yml
+++ b/codebase/config/sync/views.view.iiif_manifest.yml
@@ -7,8 +7,8 @@ dependencies:
     - field.storage.media.field_media_image
   module:
     - file
+    - idc_ui_module
     - image
-    - islandora_iiif
     - media
     - node
     - rest
@@ -368,7 +368,7 @@ display:
         options:
           offset: 0
       style:
-        type: iiif_manifest
+        type: idc_iiif_serializer
         options:
           iiif_tile_field:
             field_media_file: field_media_file

--- a/end-to-end/tests/s3.spec.js
+++ b/end-to-end/tests/s3.spec.js
@@ -60,7 +60,7 @@ test('Verify original file and derivatives are in S3', async t => {
     // list its media
 
     await t.click(io)
-    await t.click(Selector('#rid-content').find('a').withText('Media'))
+    await t.click(Selector('#block-tabs').find('a').withText('Media'))
 
     // assert the presence of the original media
     const media_name = "S3 Image";
@@ -108,12 +108,12 @@ test('Verify original file and derivatives are in S3', async t => {
         const minio_src = drupal_src.replace('/system/files',' http://minio:9000/idc/local').trim();
         var statusCode;
         const executeReq = () => {
-    
+
             const options = {
                 method:   'HEAD',
                 timeout: 1000
             };
-    
+
             return new Promise(resolve => {
                 const req = http.request(minio_src, options, (res) => {
                     statusCode = res.statusCode;
@@ -122,7 +122,7 @@ test('Verify original file and derivatives are in S3', async t => {
                 req.end();
             });
         };
-    
+
         await executeReq();
         await t.expect(statusCode).eql(200, kind + "file not in S3: " + minio_src);
     }

--- a/tests/12-media-tests/testcafe/migrate_derivative.spec.js
+++ b/tests/12-media-tests/testcafe/migrate_derivative.spec.js
@@ -37,7 +37,7 @@ test('Migrate Images for Derivative Generation', async t => {
     // list its media
 
     await t.click(io)
-    await t.click(Selector('#rid-content').find('a').withText('Media'))
+    await t.click(Selector('#block-tabs').find('a').withText('Media'))
 
     // assert the presence of the original media
     const media_name = "Map Image";

--- a/tests/12-media-tests/testcafe/util.js
+++ b/tests/12-media-tests/testcafe/util.js
@@ -26,7 +26,7 @@ const contentList = "https://islandora-idc.traefik.me/admin/content";
 export const findMediaOf = async (t, name) => {
   await navigateToMediaPage(t, name);
 
-  await t.click(Selector("#rid-content").find("a").withText("Media"));
+  await t.click(Selector("#block-tabs").find("a").withText("Media"));
 
   // assert the presence of the original media
   const media_rows = Selector(".views-table").child("tbody").child("tr");
@@ -136,7 +136,7 @@ export const download = async (uri) => {
  */
 export const uploadImageInUI = async (t, name, file) => {
   await navigateToMediaPage(t, name);
-  await t.click(Selector("#rid-content").find("a").withText("Media"));
+  await t.click(Selector("#block-tabs").find("a").withText("Media"));
   await t.click(Selector(".button"));
   await t.click(Selector(".admin-list").find("a").withText("local images"));
   await t.click(Selector("#edit-field-media-use-17"));


### PR DESCRIPTION
This adds advanced search features developed in the iDC UI Theme and adds support of media viewers for a variety of media types for the item detail page and provides general styling for the item detail page.

To test:

Viewers:
- pdfs: add a repository item and an associated document media type with a pdf attached, see that pdf.js viewer displays the pdf on the item detail page.
- oral history item: add a repository item and an associated audio media type with an mp3 audio file attached and an associated document media type with a pdf attached, see that both the audio player and the pdf.js viewer are rendered on the item detail page.
- paged content/complex media: add a paged content repository item and add at least one page repository item that is a member of the paged content item you just created and add an associated image media type to the page item. See that mirador.js viewer will display the pages on the paged content item and the individual page items will display the image without a viewer on their detail pages.
- video: add a moving image repository item and an associated video media type with a mp4 video attached. See that the video is rendered on the item detail page with controls.
- openseadragon item: add an image repository item and use the openseadragon display hint and add an associated image media type. See that open seadragon viewer renders in the item detail page.

Advanced Search:
- With some content added, visit the `/advanced-search` route by directly manipulating the url in the browser or by clicking the "Advanced Search" text under the search input located in the page header.
- Note that the advanced search controls will display above the list of results. Perform searches utilizing these controls and the newly added filters available in the left sidebar of the page.
- It should be possible to perform both word proximity searches and general advanced search queries by adding search parameters as needed.

![117871752-c9187480-b26b-11eb-9e99-eb5a194b7c6a](https://user-images.githubusercontent.com/6305935/119165707-c536e000-ba2b-11eb-8fcf-cddd181c44c5.png)



![2021-05-13 14 38 14](https://user-images.githubusercontent.com/6305935/119165572-9fa9d680-ba2b-11eb-8958-0bfca193b2c6.gif)
![2021-05-13 14 36 54](https://user-images.githubusercontent.com/6305935/119165587-a5072100-ba2b-11eb-8383-a01a4b09749f.gif)
![2021-05-13 14 26 58](https://user-images.githubusercontent.com/6305935/119165592-a6384e00-ba2b-11eb-9519-c00595d23aff.gif)
