### PR TITLE
Use https for microservice URIs

### DIFF
--- a/codebase/composer.json
+++ b/codebase/composer.json
@@ -169,6 +169,9 @@
             "drupal/title_length": {
                 "Node title length 1: Apply user config override": "patches/node_title_length_fix-hook-install.patch",
                 "Node title length 2: Taxonomy name length": "patches/node_title_length_termNameCharLength-3041979-8.patch"
+            },
+            "islandora/islandora": {
+                "Routing definitions": "patches/islandora.routing.yml.patch"
             }
         }
     }

--- a/codebase/patches/islandora.routing.yml.patch
+++ b/codebase/patches/islandora.routing.yml.patch
@@ -1,0 +1,13 @@
+diff --git a/islandora.routing.yml b/islandora.routing.yml
+index 3bdfdf53..b9ef436d 100644
+--- a/islandora.routing.yml
++++ b/islandora.routing.yml
+@@ -57,6 +57,8 @@ islandora.media_source_put_to_node:
+     _custom_access: '\Drupal\islandora\Controller\MediaSourceController::putToNodeAccess'
+   options:
+     _auth: ['basic_auth', 'cookie', 'jwt_auth']
++    default_url_options:
++      https: true
+ 
+ islandora.attach_file_to_media:
+   path: '/media/add_derivative/{media}/{destination_field}'

--- a/docker-compose.drupal.yml
+++ b/docker-compose.drupal.yml
@@ -24,8 +24,4 @@ services:
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.tls=true
     networks:
       default:
-        # Allow services (like Matomo) to use the edge name to reference this service in addition to `drupal`.
-        aliases:
-            - islandora-${COMPOSE_PROJECT_NAME-isle-dc}.${DRUPAL_SITE_HOST-traefik.me}
-            - islandora-${COMPOSE_PROJECT_NAME-isle-dc}-${DRUPAL_SITE_HOST-traefik.me}
       gateway:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -9,6 +9,7 @@
 # discover it via Docker but will not be able to redirect traffic to it.
 version: "3.7"
 networks:
+  default:
   gateway:
     name: gateway
     driver: bridge
@@ -51,4 +52,7 @@ services:
       # Do not expose in production.
       - traefik.http.routers.api.service=api@internal
     networks:
-      - gateway
+      default:
+        aliases:
+          - islandora-${COMPOSE_PROJECT_NAME-isle-dc}.${DRUPAL_SITE_HOST-traefik.me}
+          - islandora-${COMPOSE_PROJECT_NAME-isle-dc}-${DRUPAL_SITE_HOST-traefik.me}


### PR DESCRIPTION
This addresses an issue found in the cloud whereby Alpaca cannot handle redirects from http->https.  The solution offered in this PR is a quick fix, involving:
* Force Drupal to provide `https` URIs to microservices, so that microservices will interact with Drupal over https only
* Tweak the development environment so that all backend traffic to Drupal is routed through traefik, thus allowing ssl termination.

## To test in the dev environment
* `make reset`
* Edit `docker-compose.yml`, and remove the `default:` aliases for the `traefik` service.
* do `docker-compose down -v`, then `make up`.  
* Run media tests `make test test=12-media-tests`.  They should _fail_.

## To test in the cloud
I've pushed a `drupal-static` image with this fix.  Deploy _ghcr.io/jhu-sheridan-libraries/idc-isle-dc/***drupal-static:upstream-20201007-739693ae-290-gda87f78***_, and see if derivatives start working.

Resolves #137