### PR TITLE
Add contact form for repository items

### DIFF
--- a/.env
+++ b/.env
@@ -73,7 +73,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-27-g6cd914d
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-308-gc1b9d7e.1622720110
+SNAPSHOT_TAG=upstream-20201007-739693ae-300-g6dee1b5.1623094229
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21cbc1aab0f92efbdca1a4b29dab88cf",
+    "content-hash": "43f8ff82752b3dd00d7fa50a6d77f778",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -7577,6 +7577,11 @@
                 "drupal/transliterate_filenames": "Sanitizes filenames when they are uploaded so they don't break your repository."
             },
             "type": "drupal-module",
+            "extra": {
+                "patches_applied": {
+                    "Routing definitions": "patches/islandora.routing.yml.patch"
+                }
+            },
             "license": [
                 "GPL-2.0+"
             ],
@@ -7748,12 +7753,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "3709478b3cf088372f2008695c9e4bc1f0d66d25"
+                "reference": "31bae6d2f6ac9782938f2f4a389518ecd35ea0fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/3709478b3cf088372f2008695c9e4bc1f0d66d25",
-                "reference": "3709478b3cf088372f2008695c9e4bc1f0d66d25",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/31bae6d2f6ac9782938f2f4a389518ecd35ea0fa",
+                "reference": "31bae6d2f6ac9782938f2f4a389518ecd35ea0fa",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -7762,7 +7767,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/develop",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-05-24T15:54:58+00:00"
+            "time": "2021-06-02T20:10:05+00:00"
         },
         {
             "name": "jhu-idc/idc_export",
@@ -7802,12 +7807,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "aa0037b451499d2ba8135141892b0e83631f16a6"
+                "reference": "b34edf5fe18404e2a501bb497984062614410378"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/aa0037b451499d2ba8135141892b0e83631f16a6",
-                "reference": "aa0037b451499d2ba8135141892b0e83631f16a6",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/b34edf5fe18404e2a501bb497984062614410378",
+                "reference": "b34edf5fe18404e2a501bb497984062614410378",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -7816,7 +7821,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2021-05-19T18:36:02+00:00"
+            "time": "2021-06-02T15:57:59+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",

--- a/codebase/config/sync/block.block.contactblock_2.yml
+++ b/codebase/config/sync/block.block.contactblock_2.yml
@@ -1,0 +1,48 @@
+uuid: 5db23ffa-cd8a-46a1-a3ea-bea4b776fa7f
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.repository_item_contact
+  module:
+    - contact_block
+    - context
+    - islandora
+    - node
+  theme:
+    - idcui
+id: contactblock_2
+theme: idcui
+region: modal
+weight: 0
+provider: null
+plugin: contact_block
+settings:
+  id: contact_block
+  label: 'Leave feedback for ask a question about this item'
+  provider: contact_block
+  label_display: visible
+  contact_form: repository_item_contact
+visibility:
+  view_inclusion:
+    id: view_inclusion
+    negate: null
+    view_inclusion: {  }
+    context_mapping: {  }
+  request_path_exclusion:
+    id: request_path_exclusion
+    pages: ''
+    negate: null
+    context_mapping: {  }
+  media_source_mimetype:
+    id: media_source_mimetype
+    mimetype: ''
+    negate: false
+    context_mapping: {  }
+  node_type:
+    id: node_type
+    bundles:
+      islandora_object: islandora_object
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/codebase/config/sync/contact.form.repository_item_contact.yml
+++ b/codebase/config/sync/contact.form.repository_item_contact.yml
@@ -1,0 +1,27 @@
+uuid: 3d277044-a993-468e-9dea-a317fc15a35d
+langcode: en
+status: true
+dependencies:
+  module:
+    - contact_ajax
+    - contact_storage
+third_party_settings:
+  contact_ajax:
+    enabled: true
+    prefix_id: ''
+    render_selector: ''
+    confirmation_type: 1
+  contact_storage:
+    submit_text: 'Send message'
+    show_preview: false
+    disabled_form_message: 'This contact form has been disabled.'
+    maximum_submissions_user: 0
+    page_autoreply_format: plain_text
+id: repository_item_contact
+label: 'Repository Item Contact'
+recipients:
+  - web@localhost
+reply: ''
+weight: 0
+message: ''
+redirect: ''

--- a/codebase/config/sync/core.entity_form_display.contact_message.repository_item_contact.default.yml
+++ b/codebase/config/sync/core.entity_form_display.contact_message.repository_item_contact.default.yml
@@ -1,0 +1,66 @@
+uuid: b48e1ed3-354d-4c2a-a710-2a167ccd66c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.repository_item_contact
+    - field.field.contact_message.repository_item_contact.field_collection
+id: contact_message.repository_item_contact.default
+targetEntityType: contact_message
+bundle: repository_item_contact
+mode: default
+content:
+  copy:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_collection:
+    weight: 51
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  mail:
+    weight: -40
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  message:
+    type: string_textarea
+    weight: 0
+    settings:
+      rows: 12
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+  name:
+    weight: -50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  preview:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  subject:
+    type: string_textfield
+    weight: -10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/codebase/config/sync/core.entity_view_display.contact_message.repository_item_contact.default.yml
+++ b/codebase/config/sync/core.entity_view_display.contact_message.repository_item_contact.default.yml
@@ -1,0 +1,54 @@
+uuid: 8977838e-b746-4dbb-a745-67133ee16020
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.repository_item_contact
+    - field.field.contact_message.repository_item_contact.field_collection
+id: contact_message.repository_item_contact.default
+targetEntityType: contact_message
+bundle: repository_item_contact
+mode: default
+content:
+  field_collection:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  mail:
+    weight: -2
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+  message:
+    type: string
+    weight: 0
+    label: above
+    region: content
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  name:
+    weight: -3
+    region: content
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  subject:
+    weight: -1
+    region: content
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/codebase/config/sync/field.field.contact_message.repository_item_contact.field_collection.yml
+++ b/codebase/config/sync/field.field.contact_message.repository_item_contact.field_collection.yml
@@ -1,0 +1,34 @@
+uuid: e7589999-dbb7-4396-875a-795f5122d37e
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.repository_item_contact
+    - field.storage.contact_message.field_collection
+    - node.type.collection_object
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: '[idc_token_group:repo_item_parent]'
+    on_update: 1
+id: contact_message.repository_item_contact.field_collection
+field_name: field_collection
+entity_type: contact_message
+bundle: repository_item_contact
+label: 'Parent Collection'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      collection_object: collection_object
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference


### PR DESCRIPTION
* Add a new contact form in the modal region of the theme present only on the repository item detail pages
* Add JS controller that will open the contact form modal
* Add custom token that will return the parent collection of a repository item

Since email service isn't yet hooked up, you can check behavior by:

* Create new Collection, with a contact name and email
* Create new repository item that belongs to the new collection
* Navigate to the new item's page, click on the "Ask collection admin" button to open the contact form
  * Parent Collection field at the bottom of the form should be prepopulated with the collection you created
  * If you open this contact form as an anonymous user (not logged in), you should be presented with a CAPTCHA
* Fill out the form and click the Send button
  * You'll get an error message in the modal area
  * If you check the recent log messages in Admin -> Reports -> Recent log messages, you should see an error of type `mail` and a message with type `contact`. The mail message should say something like "Error sending email (from _webmaster@localhost.com_ to _moo@example.com_ with reply-to _moo@example.com_)"
    * This message should include the email address you set as your collection contact email