### PR TITLE
Fix failing media tests

### DIFF
--- a/tests/12-media-tests.sh
+++ b/tests/12-media-tests.sh
@@ -8,5 +8,5 @@ TESTCAFE_TESTS_FOLDER="$(pwd)/$(dirname $0)/$(basename $0 .sh)/testcafe"
 startMigrationAssetsContainer
 
 # Execute migrations using testcafe
-docker run --network gateway --env-file "${ENV_FILE}" -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.init.js
-docker run --network gateway --env-file "${ENV_FILE}" -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.spec.js
+docker run --rm --network gateway --env-file "${ENV_FILE}" -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.init.js
+docker run --rm --network gateway --env-file "${ENV_FILE}" -v "${TESTCAFE_TESTS_FOLDER}":/tests testcafe/testcafe --screenshots path=/tests/screenshots,takeOnFails=true chromium /tests/**/*.spec.js

--- a/tests/12-media-tests/testcafe/migrations/media-format-image.csv
+++ b/tests/12-media-tests/testcafe/migrations/media-format-image.csv
@@ -1,3 +1,3 @@
 local_id,name,original_name,mime_type,media_of,media_use,url,alt_text
-media_format_file_tiff_01,Tiff Image,tiff.tif,image/tiff,media_format_object_01,Original File,http://migration-assets/assets/image/formats/tiff.tif,tiff
-media_format_file_tiff_02,Jpeg 2000 Image,jp2.jp2,image/jp2,media_format_object_03,Original File,http://migration-assets/assets/image/formats/jp2.jp2,jp2
+media_format_file_tiff_01,Tiff Image,tiff.tif,image/tiff,:::Migrated Tiff Object,Original File,http://migration-assets/assets/image/formats/tiff.tif,tiff
+media_format_file_tiff_02,Jpeg 2000 Image,jp2.jp2,image/jp2,:::Migrated JPEG2000 Object,Original File,http://migration-assets/assets/image/formats/jp2.jp2,jp2


### PR DESCRIPTION
There seem to have been a couple issues issues at play:

* testcafe was navigating away from migration upload page before migrations were done, this PR explicitly waits for migration status messages to appear.
* Image migration file used old local ID reference format instead of new entity reference format, so all migrations of test image binaries were failing unnoticed.

The error reporting mechanism of migrations still is quite poor/insufficient.  I ultimately resorted to looking for the text "0 failures" in the status box.  Actually finding the _cause_ of migration errors requires digging around db tables, since there is no UI element that explains causes of migration failure, and migration logs are separate and distinct from Drupal's central logging mechanism (and therefore doesn't seem to be visible in reports).

## To test
* Verify that tests pass for this PR
* look over testcafe code tweaks for correctness.

Resolves #141 