### PR TITLE
Do not include database name in dumps

### DIFF
--- a/.env
+++ b/.env
@@ -73,7 +73,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-27-g6cd914d
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-300-g6dee1b5.1623094229
+SNAPSHOT_TAG=upstream-20201007-739693ae-303-g7c80190.1623344224
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -201,7 +201,7 @@ test:
 .PHONY: db_dump
 .SILENT: db_dump
 db_dump:
-	docker-compose exec -T mariadb bash -c "mysqldump --databases drupal_default --add-drop-database > /mariadb-dump/drupal_default.sql"
+	docker-compose exec -T mariadb bash -c "mysqldump drupal_default --add-drop-database > /mariadb-dump/drupal_default.sql"
 
 .PHONY: db_restore
 .SILENT: db_restore
@@ -211,8 +211,10 @@ db_restore:
 	fi; \
 	echo "Creating mysql user $${DRUPAL_DEFAULT_DB_USER}"
 	docker-compose exec -T mariadb mysql mysql -e "CREATE USER IF NOT EXISTS '$${DRUPAL_DEFAULT_DB_USER}'@'%' IDENTIFIED BY '${DRUPAL_DEFAULT_DB_PASSWORD}'; FLUSH PRIVILEGES"; \
+	docker-compose exec -T mariadb bash -c 'mysql mysql -e "DROP DATABASE IF EXISTS drupal_default"'; \
+	docker-compose exec -T mariadb bash -c 'mysql mysql -e "CREATE DATABASE drupal_default DEFAULT CHARACTER SET utf8"'; \
 	echo "Loading mysql dump"; \
-		docker-compose exec -T mariadb bash -c 'mysql mysql < /mariadb-dump/drupal_default.sql'; \
+	docker-compose exec -T mariadb bash -c 'mysql drupal_default < /mariadb-dump/drupal_default.sql'; \
 	docker-compose exec -T mariadb mysql mysql -e "GRANT ALL PRIVILEGES ON drupal_default.* to '$${DRUPAL_DEFAULT_DB_USER}'@'%';";
 
 .phony: minio-bucket

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -201,7 +201,7 @@ test:
 .PHONY: db_dump
 .SILENT: db_dump
 db_dump:
-	docker-compose exec -T mariadb bash -c "mysqldump drupal_default --add-drop-database > /mariadb-dump/drupal_default.sql"
+	docker-compose exec -T mariadb bash -c "mysqldump drupal_default > /mariadb-dump/drupal_default.sql"
 
 .PHONY: db_restore
 .SILENT: db_restore


### PR DESCRIPTION
Separates the DDL statements out into the idc Makefile, and removes the
--databases tag from mysqldump, so that db dumps contain only table
data, not dabase CREATE and DROP and USE statements.

Future snapshots will not contain db dumps containing db names.

# To verify

look at the contents of `ghcr.io/jhu-sheridan-libraries/idc-isle-dc/snapshot:upstream-20201007-739693ae-303-g7c80190.1623344224`, and verify the mysql dump does not have database DDL statements in it.

Resolves #146