### PR TITLE
Add drupal core-vendor-hardening

### DIFF
--- a/codebase/composer.json
+++ b/codebase/composer.json
@@ -92,6 +92,7 @@
         "drupal/core-composer-scaffold": "^8.9.16",
         "drupal/core-project-message": "^8.9.16",
         "drupal/core-recommended": "^8.9.16",
+        "drupal/core-vendor-hardening": "^9.2",
         "drupal/devel": "^2.0",
         "drupal/embed": "^1.4",
         "drupal/entity_reference_unpublished": "^1.2",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58892dd09e09c5ba6d0598eec615cf26",
+    "content-hash": "e7ff55a580c50ac27cc0a0f5f88205d0",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3286,6 +3286,44 @@
             ],
             "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
             "time": "2021-05-25T09:17:58+00:00"
+        },
+        {
+            "name": "drupal/core-vendor-hardening",
+            "version": "9.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drupal/core-vendor-hardening.git",
+                "reference": "f9eaafd58792fef38037979c2344a9216a93cc7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drupal/core-vendor-hardening/zipball/f9eaafd58792fef38037979c2344a9216a93cc7e",
+                "reference": "f9eaafd58792fef38037979c2344a9216a93cc7e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2",
+                "php": ">=7.3.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Drupal\\Composer\\Plugin\\VendorHardening\\VendorHardeningPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Drupal\\Composer\\Plugin\\VendorHardening\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Hardens the vendor directory for when it's in the docroot.",
+            "homepage": "https://www.drupal.org/project/drupal",
+            "keywords": [
+                "drupal"
+            ],
+            "time": "2021-04-22T15:46:23+00:00"
         },
         {
             "name": "drupal/csv_serialization",
@@ -7038,7 +7076,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/chullo/zipball/d563d5e48ef9b15dcf45029277bbc2f6eeef2454",
+                "url": "https://api.github.com/repos/Islandora/chullo/zipball/7f7df8847844ab478f65de8377c5678d037cb5e3",
                 "reference": "7f7df8847844ab478f65de8377c5678d037cb5e3",
                 "shasum": ""
             },
@@ -7095,7 +7133,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/Crayfish-Commons/zipball/46a1f1b63bdb47d07ed58e5f1d388af1ffd27185",
+                "url": "https://api.github.com/repos/Islandora/Crayfish-Commons/zipball/748c59cd1ddce9ddc9a05e25594cc6a9b230f9c1",
                 "reference": "748c59cd1ddce9ddc9a05e25594cc6a9b230f9c1",
                 "shasum": ""
             },
@@ -7154,7 +7192,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/islandora/zipball/cf82e8f392c081221781fd568cfc11d1bde7fd87",
+                "url": "https://api.github.com/repos/Islandora/islandora/zipball/d76a6644c919acaa48d59d862a4fc6e8a279be2d",
                 "reference": "d76a6644c919acaa48d59d862a4fc6e8a279be2d",
                 "shasum": ""
             },
@@ -7228,7 +7266,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/jsonld/zipball/dfd99c4c1beac54efc0eaa6cdbadc01d4918fd6c",
+                "url": "https://api.github.com/repos/Islandora/jsonld/zipball/3281e15d7b341cb7195361c0dd2b5314c893cb22",
                 "reference": "3281e15d7b341cb7195361c0dd2b5314c893cb22",
                 "shasum": ""
             },
@@ -7263,7 +7301,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Islandora/openseadragon/zipball/5f847e56c032ddc4c5b19f4350caaec90873a54c",
+                "url": "https://api.github.com/repos/Islandora/openseadragon/zipball/0fd1218f929cb4fd1537f52647f35f4248ce0fc0",
                 "reference": "0fd1218f929cb4fd1537f52647f35f4248ce0fc0",
                 "shasum": ""
             },
@@ -7366,7 +7404,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/b6a90d7e012e1a5701424db1a14feae00baf4a4d",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/31bae6d2f6ac9782938f2f4a389518ecd35ea0fa",
                 "reference": "31bae6d2f6ac9782938f2f4a389518ecd35ea0fa",
                 "shasum": ""
             },
@@ -7388,7 +7426,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_export/zipball/f162dd757b1b09ccab27a4bfcd2baf70ced43564",
+                "url": "https://api.github.com/repos/jhu-idc/idc_export/zipball/61b5ef3115bf05c9aa6f851a56e65c4ac8e8d895",
                 "reference": "61b5ef3115bf05c9aa6f851a56e65c4ac8e8d895",
                 "shasum": ""
             },
@@ -7421,7 +7459,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/ccfb31419e3f1b1b1c46cc325552211ee464c50d",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/2315e6824f10f68f83c6005b4bc9f16f46bdd997",
                 "reference": "2315e6824f10f68f83c6005b4bc9f16f46bdd997",
                 "shasum": ""
             },
@@ -15872,7 +15910,8 @@
             "homepage": "https://www.drupal.org/project/adaptivetheme",
             "support": {
                 "source": "https://git.drupalcode.org/project/adaptivetheme"
-            }
+            },
+            "time": "2018-03-14T21:12:35+00:00"
         },
         {
             "name": "drupal/coder",


### PR DESCRIPTION
Security-related fix recommended by @jordandukart. Sanitizes the vendor directory, recommended for production sites.

There's nothing to manually test, other than verifying that CI tests still pass.

Resolves #151 