### PR TITLE
Use parallel test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,9 @@ on:
       - development
 
 jobs:
-    everything:
-        name: Build, Test, or Deploy
+    build:
+        name: build
         runs-on: ubuntu-latest
-        timeout-minutes: 45
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
         steps:
@@ -39,22 +38,50 @@ jobs:
             - name: Drush test
               run: docker-compose exec -T drupal drush -d status
 
-            # Run end-to-end tests
-            - name: End-To-End Tests
+            - name: Export image
+              run: make static-drupal-image-export
+
+            - uses: actions/upload-artifact@v2
+              with:
+                name: drupal-image
+                path: images
+    test:
+        name: test
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+          matrix:
+            suite: 
+              - 01-end-to-end
+              - 02-static-config
+              - 10-migration-backend-tests
+              - 11-file-deletion-tests
+              - 12-media-tests
+              - 13-migration-entity-resolution
+              - 20-export-tests
+        steps:
+            - name: Download Drupal Image
+              uses: actions/download-artifact@v2
+              with:
+                name: drupal-image
+                path: images
+
+            - name: Load Drupal Image
+              run: docker load < images/static-drupal.tar
+
+            - name: Up
+              run: make up
+
+            - name: test
               run: | 
                 mkdir -p end-to-end/reports
                 chmod a+rwx end-to-end/reports
-                make test
-            
-            # Upload artifacts if tests fail
-            - name: Test Failure Forensics
-              uses: actions/upload-artifact@v2
-              if: failure()
-              with:
-                name: end-to-end-reports
-                path: end-to-end/reports         
-
-            # Log in to Docker, if we have the secrets
+                make test test=${{ matrix.suite }}
+    deploy:
+        name: Deploy
+        runs-on: ubuntu-latest
+        needs: [ build, test]
+        steps:
             - name: Docker Login
               if: contains('refs/heads/main 
                             refs/heads/development', github.ref) &&
@@ -64,6 +91,15 @@ jobs:
                 registry: ghcr.io
                 username: ${{ env.DOCKER_USER }}
                 password: ${{ secrets.DOCKER_PASS }}
+
+            - name: Download Drupal Image
+              uses: actions/download-artifact@v2
+              with:
+                name: drupal-image
+                path: images
+
+            - name: Load Drupal Image
+              run: docker load < images/static-drupal.tar
             
             # Push docker images, if we are on the appropriate branch or tag
             - name: Docker Push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,10 @@ jobs:
               shell: bash
               run: |
                   echo '{"experimental": "enabled"}' > ~/.docker/config.json
-            
-            # Initially run the development environment to make sure that succeeds
-            - name: Build Dev
-              run: make up
     
             # Build and run the static environment
             - name: Build Static 
-              run: docker-compose down -v && make static-docker-compose.yml up
+              run: make static-docker-compose.yml up
 
             # Drush tests
             - name: Drush test
@@ -60,6 +56,10 @@ jobs:
               - 13-migration-entity-resolution
               - 20-export-tests
         steps:
+            # Check out current commit
+            - name: Checkout
+              uses: actions/checkout@v2
+
             - name: Download Drupal Image
               uses: actions/download-artifact@v2
               with:
@@ -82,6 +82,10 @@ jobs:
         runs-on: ubuntu-latest
         needs: [ build, test]
         steps:
+            # Check out current commit
+            - name: Checkout
+              uses: actions/checkout@v2
+
             - name: Docker Login
               if: contains('refs/heads/main 
                             refs/heads/development', github.ref) &&

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ certs
 *node_modules
 end-to-end/reports
 screenshots/
+
+# Ignore docker images
+/images

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -173,6 +173,14 @@ static-drupal-image:
 	    echo "Using existing Drupal image $${EXISTING}" ; \
 	fi
 
+# Export a tar of the static drupal image
+.PHONY: static-drupal-image-export
+.SILENT: static-drupal-image-export
+static-drupal-image-export: static-drupal-image
+	IMAGE=${REPOSITORY}/drupal-static:${GIT_TAG} ; \
+	mkdir -p images ; \
+	docker save $${IMAGE} > images/static-drupal.tar
+
 
 # Build a docker-compose file that will run the whole stack, except with
 # the static drupal image rather than the dev drupal image + codebase bind mount.


### PR DESCRIPTION
This refactors the github build so that test suites are run in parallel,
using a matrix strategy.  Caveat: If a new test suite is created, it
needs to be added to the .github/workflows/ci.yml file!

Hopefully, this should execute in significantly less time than before.  We were exceeding the 45 minute time limit, which was becoming a drag on productivity.