### PR TITLE
Update CAPTCHA configs

### DIFF
--- a/codebase/config/sync/captcha.settings.yml
+++ b/codebase/config/sync/captcha.settings.yml
@@ -10,3 +10,4 @@ enable_stats: false
 log_wrong_responses: false
 _core:
   default_config_hash: _UaIWu0_ZD3lUs97wlFC2Koi-o7Bex69Xr9q36nJtkY
+wrong_captcha_response_message: 'The answer you entered for the CAPTCHA was not correct.'

--- a/codebase/config/sync/image_captcha.settings.yml
+++ b/codebase/config/sync/image_captcha.settings.yml
@@ -1,8 +1,7 @@
 image_captcha_fonts_preview_map_cache: {  }
 image_captcha_fonts:
-  - modules/contrib/captcha/image_captcha/fonts/Tesox/tesox.ttf
-  - modules/contrib/captcha/image_captcha/fonts/Tuffy/Tuffy.ttf
-image_captcha_font_size: 30
+  BUILTIN: BUILTIN
+image_captcha_font_size: 24
 image_captcha_character_spacing: '1.2'
 image_captcha_image_allowed_chars: aAbBCdEeFfGHhijKLMmNPQRrSTtWXYZ23456789
 image_captcha_code_length: 5
@@ -13,8 +12,8 @@ image_captcha_foreground_color_randomness: 100
 image_captcha_file_format: 1
 image_captcha_distortion_amplitude: 0
 image_captcha_bilinear_interpolation: 0
-image_captcha_dot_noise: 0
+image_captcha_dot_noise: 1
 image_captcha_line_noise: 0
-image_captcha_noise_level: 5
+image_captcha_noise_level: 1
 _core:
   default_config_hash: PBJAPRAqH-w00jAUXbD9qV6frVT38tI1oXZiBIjV8gU

--- a/codebase/config/sync/user.role.authenticated.yml
+++ b/codebase/config/sync/user.role.authenticated.yml
@@ -15,6 +15,7 @@ permissions:
   - 'opt-in or out of matomo tracking'
   - 'restful get oai_pmh'
   - 'search content'
+  - 'skip CAPTCHA'
   - 'use text format basic_html'
   - 'view field_citable_url'
   - 'view field_model'

--- a/codebase/config/sync/user.role.collection_level_admin.yml
+++ b/codebase/config/sync/user.role.collection_level_admin.yml
@@ -78,6 +78,7 @@ permissions:
   - 'restful get oai_pmh'
   - 'revert collection_object revisions'
   - 'revert islandora_object revisions'
+  - 'skip CAPTCHA'
   - 'update any media'
   - 'update media'
   - 'use text format full_html'

--- a/codebase/config/sync/user.role.fedoraadmin.yml
+++ b/codebase/config/sync/user.role.fedoraadmin.yml
@@ -8,4 +8,5 @@ id: fedoraadmin
 label: fedoraAdmin
 weight: -7
 is_admin: null
-permissions: {  }
+permissions:
+  - 'skip CAPTCHA'

--- a/codebase/config/sync/user.role.global_admin.yml
+++ b/codebase/config/sync/user.role.global_admin.yml
@@ -106,6 +106,7 @@ permissions:
   - 'restful get oai_pmh'
   - 'revert collection_object revisions'
   - 'revert islandora_object revisions'
+  - 'skip CAPTCHA'
   - 'update any media'
   - 'update media'
   - 'use text format full_html'


### PR DESCRIPTION
Fixes https://github.com/jhu-idc/iDC-general/issues/287

* Update permissions so that _only_ anonymous users (not logged in) are presented with CAPTCHA on contact forms
  * Previously, everyone except local admin was presented with CAPTCHA
  * Test SSO login by clicking Login > Federated Login > Use credentials staff1 // moo
* Update image CAPTCHA settings, as for some reason, the image was not rendering any text
  * CAPTCHA image that was supposed to have letters/numbers for the user to read was a blank white image