### PR TITLE
Fixes a few skipped delimiters in media migrations

### DIFF
--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
@@ -63,7 +63,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
@@ -63,7 +63,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
@@ -64,7 +64,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
@@ -63,7 +63,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
@@ -63,7 +63,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
@@ -29,7 +29,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
@@ -63,7 +63,7 @@ process:
       source: access_terms
     -
       plugin: explode
-      delimiter: '|'
+      delimiter: '||'
       strict: false
     -
       plugin: entity_lookup


### PR DESCRIPTION
Turns out I missed a few `|`  -> `||` changes in media migrations.  This PR brings those in. 

The interesting thing is that the media migration tests still passed as the csv data for that column was formatted correctly: `Media Group A||Media GroupB`.  I suspect it's because it parsed the strings and found 3 things, one of which was blank, so it just skipped the blank one. 