### PR TITLE
Adds field_unique_id to media

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -7425,12 +7425,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_defaults.git",
-                "reference": "c628e424fe22827a79aca45f1b3ca61f95dc66c8"
+                "reference": "f4fffc48177049325d52e5b08d8a58c8e490416f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_defaults/zipball/c628e424fe22827a79aca45f1b3ca61f95dc66c8",
-                "reference": "c628e424fe22827a79aca45f1b3ca61f95dc66c8",
+                "url": "https://api.github.com/repos/jhu-idc/idc_defaults/zipball/f4fffc48177049325d52e5b08d8a58c8e490416f",
+                "reference": "f4fffc48177049325d52e5b08d8a58c8e490416f",
                 "shasum": ""
             },
             "require": {
@@ -7443,7 +7443,7 @@
                 "source": "https://github.com/jhu-idc/idc_defaults/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_defaults/issues"
             },
-            "time": "2021-07-27T11:37:57+00:00"
+            "time": "2021-07-30T11:35:47+00:00"
         },
         {
             "name": "jhu-idc/idc_export",

--- a/codebase/config/sync/core.entity_form_display.media.audio.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.audio.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_unique_id
     - media.type.audio
   module:
     - file
@@ -63,6 +64,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_unique_id:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/codebase/config/sync/core.entity_form_display.media.document.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.document.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.document.field_media_use
     - field.field.media.document.field_mime_type
     - field.field.media.document.field_original_name
+    - field.field.media.document.field_unique_id
     - media.type.document
   module:
     - file
@@ -63,6 +64,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_unique_id:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/codebase/config/sync/core.entity_form_display.media.extracted_text.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.extracted_text.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.media.extracted_text.field_media_of
     - field.field.media.extracted_text.field_media_use
     - field.field.media.extracted_text.field_mime_type
+    - field.field.media.extracted_text.field_unique_id
     - media.type.extracted_text
   module:
     - file
@@ -48,6 +49,14 @@ content:
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
+  field_unique_id:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
     weight: 1

--- a/codebase/config/sync/core.entity_form_display.media.file.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.file.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.file.field_media_use
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
+    - field.field.media.file.field_unique_id
     - media.type.file
   module:
     - file
@@ -63,6 +64,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_unique_id:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/codebase/config/sync/core.entity_form_display.media.image.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.image.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.image.field_media_use
     - field.field.media.image.field_mime_type
     - field.field.media.image.field_original_name
+    - field.field.media.image.field_unique_id
     - field.field.media.image.field_width
     - image.style.thumbnail
     - media.type.image
@@ -67,6 +68,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_unique_id:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/codebase/config/sync/core.entity_form_display.media.remote_video.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.remote_video.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.media.remote_video.field_access_terms
     - field.field.media.remote_video.field_media_oembed_video
+    - field.field.media.remote_video.field_unique_id
     - media.type.remote_video
   module:
     - media
@@ -35,6 +36,14 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
+  field_unique_id:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   langcode:
     type: language_select

--- a/codebase/config/sync/core.entity_form_display.media.video.default.yml
+++ b/codebase/config/sync/core.entity_form_display.media.video.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_unique_id
     - media.type.video
   module:
     - file
@@ -63,6 +64,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
+    region: content
+  field_unique_id:
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/codebase/config/sync/core.entity_view_display.media.audio.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.audio.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_unique_id
     - media.type.audio
   module:
     - file
@@ -38,10 +39,10 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
   field_gemini_uri:
-    weight: 100
+    weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_audio_file:
     type: file_audio
     weight: 1
@@ -78,7 +79,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_original_name:
-    weight: 101
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -94,6 +95,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/codebase/config/sync/core.entity_view_display.media.audio.source.yml
+++ b/codebase/config/sync/core.entity_view_display.media.audio.source.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.audio.field_media_use
     - field.field.media.audio.field_mime_type
     - field.field.media.audio.field_original_name
+    - field.field.media.audio.field_unique_id
     - media.type.audio
   enforced:
     module:
@@ -48,6 +49,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.document.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.document.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.document.field_media_use
     - field.field.media.document.field_mime_type
     - field.field.media.document.field_original_name
+    - field.field.media.document.field_unique_id
     - media.type.document
   module:
     - file
@@ -75,7 +76,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_original_name:
-    weight: 101
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -91,6 +92,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/codebase/config/sync/core.entity_view_display.media.document.pdfjs.yml
+++ b/codebase/config/sync/core.entity_view_display.media.document.pdfjs.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.document.field_media_use
     - field.field.media.document.field_mime_type
     - field.field.media.document.field_original_name
+    - field.field.media.document.field_unique_id
     - media.type.document
   module:
     - pdf
@@ -44,6 +45,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.document.source.yml
+++ b/codebase/config/sync/core.entity_view_display.media.document.source.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.document.field_media_use
     - field.field.media.document.field_mime_type
     - field.field.media.document.field_original_name
+    - field.field.media.document.field_unique_id
     - media.type.document
   enforced:
     module:
@@ -41,6 +42,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.extracted_text.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.extracted_text.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.media.extracted_text.field_media_of
     - field.field.media.extracted_text.field_media_use
     - field.field.media.extracted_text.field_mime_type
+    - field.field.media.extracted_text.field_unique_id
     - media.type.extracted_text
   module:
     - file
@@ -62,6 +63,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
+  field_unique_id:
+    weight: 6
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   uid:
     label: hidden
     type: author

--- a/codebase/config/sync/core.entity_view_display.media.file.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.file.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.file.field_media_use
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
+    - field.field.media.file.field_unique_id
     - media.type.file
   module:
     - file
@@ -38,10 +39,10 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
   field_gemini_uri:
-    weight: 100
+    weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_file:
     label: visually_hidden
     settings:
@@ -75,7 +76,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_original_name:
-    weight: 101
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -91,6 +92,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/codebase/config/sync/core.entity_view_display.media.file.open_seadragon.yml
+++ b/codebase/config/sync/core.entity_view_display.media.file.open_seadragon.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.file.field_media_use
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
+    - field.field.media.file.field_unique_id
     - media.type.file
   enforced:
     module:
@@ -40,6 +41,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.file.pdfjs.yml
+++ b/codebase/config/sync/core.entity_view_display.media.file.pdfjs.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.file.field_media_use
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
+    - field.field.media.file.field_unique_id
     - media.type.file
   module:
     - pdf
@@ -44,6 +45,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.file.source.yml
+++ b/codebase/config/sync/core.entity_view_display.media.file.source.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.file.field_media_use
     - field.field.media.file.field_mime_type
     - field.field.media.file.field_original_name
+    - field.field.media.file.field_unique_id
     - media.type.file
   enforced:
     module:
@@ -41,6 +42,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.image.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.image.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.image.field_media_use
     - field.field.media.image.field_mime_type
     - field.field.media.image.field_original_name
+    - field.field.media.image.field_unique_id
     - field.field.media.image.field_width
     - media.type.image
   module:
@@ -40,10 +41,10 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
   field_gemini_uri:
-    weight: 100
+    weight: 9
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_height:
     type: number_integer
     weight: 5
@@ -87,7 +88,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_original_name:
-    weight: 101
+    weight: 10
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -112,6 +113,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/codebase/config/sync/core.entity_view_display.media.image.open_seadragon.yml
+++ b/codebase/config/sync/core.entity_view_display.media.image.open_seadragon.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.media.image.field_media_use
     - field.field.media.image.field_mime_type
     - field.field.media.image.field_original_name
+    - field.field.media.image.field_unique_id
     - field.field.media.image.field_width
     - media.type.image
   enforced:
@@ -43,6 +44,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   field_width: true
   langcode: true
   name: true

--- a/codebase/config/sync/core.entity_view_display.media.image.source.yml
+++ b/codebase/config/sync/core.entity_view_display.media.image.source.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.media.image.field_media_use
     - field.field.media.image.field_mime_type
     - field.field.media.image.field_original_name
+    - field.field.media.image.field_unique_id
     - field.field.media.image.field_width
     - media.type.image
   enforced:
@@ -45,6 +46,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   field_width: true
   langcode: true
   name: true

--- a/codebase/config/sync/core.entity_view_display.media.remote_video.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.remote_video.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.media.remote_video.field_access_terms
     - field.field.media.remote_video.field_media_oembed_video
+    - field.field.media.remote_video.field_unique_id
     - media.type.remote_video
   module:
     - media
@@ -34,6 +35,7 @@ content:
     region: content
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/core.entity_view_display.media.video.default.yml
+++ b/codebase/config/sync/core.entity_view_display.media.video.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_unique_id
     - media.type.video
   module:
     - file
@@ -38,10 +39,10 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
   field_gemini_uri:
-    weight: 100
+    weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_media_of:
     type: entity_reference_label
     weight: 4
@@ -81,7 +82,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
   field_original_name:
-    weight: 101
+    weight: 8
     label: above
     settings: {  }
     third_party_settings: {  }
@@ -97,6 +98,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_unique_id: true
   langcode: true
   search_api_excerpt: true
   thumbnail: true

--- a/codebase/config/sync/core.entity_view_display.media.video.source.yml
+++ b/codebase/config/sync/core.entity_view_display.media.video.source.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.media.video.field_media_video_file
     - field.field.media.video.field_mime_type
     - field.field.media.video.field_original_name
+    - field.field.media.video.field_unique_id
     - media.type.video
   enforced:
     module:
@@ -51,6 +52,7 @@ hidden:
   field_media_use: true
   field_mime_type: true
   field_original_name: true
+  field_unique_id: true
   langcode: true
   name: true
   search_api_excerpt: true

--- a/codebase/config/sync/field.field.media.audio.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.audio.field_unique_id.yml
@@ -7,9 +7,10 @@ dependencies:
     - media.type.audio
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
-    value: '[random:md5:?]'
+    value: ''
     on_update: 0
 id: media.audio.field_unique_id
 field_name: field_unique_id
@@ -22,4 +23,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.audio.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.audio.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: 227de37f-dd5e-4753-b8c4-303a247472e5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.audio
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: '[random:md5:?]'
+    on_update: 0
+id: media.audio.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: audio
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.document.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.document.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: b291e424-b552-44b1-a952-65c17d6f698e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.document
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.document.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: document
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.document.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.document.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.document
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.extracted_text.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.extracted_text.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.extracted_text
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.extracted_text.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.extracted_text.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: b1aa1e24-6823-4839-b640-1e26728d7f3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.extracted_text
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.extracted_text.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: extracted_text
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.file.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.file.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.file
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.file.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.file.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: 385ce822-82d7-4468-9826-925770f67b17
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.file
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.file.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: file
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.image.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.image.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: 8b825a8a-e59b-406d-bf47-306292698d25
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.image
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.image.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: image
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.image.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.image.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.image
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.remote_video.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.remote_video.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.remote_video
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.field.media.remote_video.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.remote_video.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: db0e43d4-0572-420e-9361-acd6582e7200
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.remote_video
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.remote_video.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: remote_video
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.video.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.video.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: c32edb16-1ac4-4732-90ae-7a8f28fb8a6e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_unique_id
+    - media.type.video
+  module:
+    - epp
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 1
+id: media.video.field_unique_id
+field_name: field_unique_id
+entity_type: media
+bundle: video
+label: 'Unique ID'
+description: 'This is the system''s unique identifier for this field.  Generally this should not be edited after the item is created. '
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/codebase/config/sync/field.field.media.video.field_unique_id.yml
+++ b/codebase/config/sync/field.field.media.video.field_unique_id.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.video
   module:
     - epp
+    - idc_defaults
 third_party_settings:
   epp:
     value: ''
@@ -22,4 +23,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: idc_unique

--- a/codebase/config/sync/field.storage.media.field_unique_id.yml
+++ b/codebase/config/sync/field.storage.media.field_unique_id.yml
@@ -1,0 +1,25 @@
+uuid: 2968ac8f-aacd-47ed-b3fa-2a3b8b69ee3e
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - media
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: media.field_unique_id
+field_name: field_unique_id
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/codebase/config/sync/field.storage.media.field_unique_id.yml
+++ b/codebase/config/sync/field.storage.media.field_unique_id.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - field_permissions
+    - idc_defaults
     - media
 third_party_settings:
   field_permissions:
@@ -11,12 +12,12 @@ third_party_settings:
 id: media.field_unique_id
 field_name: field_unique_id
 entity_type: media
-type: string
+type: idc_unique
 settings:
-  max_length: 255
-  is_ascii: false
+  max_length: '128'
+  is_ascii: true
   case_sensitive: false
-module: core
+module: idc_defaults
 locked: false
 cardinality: 1
 translatable: true

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
@@ -12,7 +12,7 @@ label: '(3g) Ingest New Audio Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,6 +21,7 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
@@ -12,7 +12,7 @@ label: '(3c) Ingest New Document (e.g. PDF) Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,6 +21,7 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
@@ -12,7 +12,7 @@ label: '(3d) Ingest New Extracted Text Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -22,6 +22,7 @@ source:
     TMP_FS: /tmp/
     FORMAT: basic_html
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
@@ -12,7 +12,7 @@ label: '(3b) Ingest New Generic File Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,6 +21,7 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
@@ -12,7 +12,7 @@ label: '(3a) Ingest New Image Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,6 +21,7 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
@@ -12,7 +12,7 @@ label: '(3f) Ingest Remote Video Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,7 +21,8 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
-  name: name
+  field_unique_id: unique_id
+  name: nam
   field_access_terms:
     -
       plugin: skip_on_empty

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_remote_video.yml
@@ -22,7 +22,7 @@ source:
     TMP_FS: /tmp/
 process:
   field_unique_id: unique_id
-  name: nam
+  name: name
   field_access_terms:
     -
       plugin: skip_on_empty

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
@@ -12,7 +12,7 @@ label: '(3e) Ingest New Video Media'
 source:
   plugin: idc_csv
   ids:
-    - local_id
+    - unique_id
   path: 'Will be populated by the Migrate Source UI'
   constants:
     STATUS: true
@@ -21,6 +21,7 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
 process:
+  field_unique_id: unique_id
   _url_filename:
     -
       plugin: callback

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-accessterms.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-accessterms.csv
@@ -1,3 +1,3 @@
-local_id,name,parent,description
+unique_id,name,parent,description
 media_accesscontrol_01,Media Group A,,"<p>Access group A for media tests</p>",
 media_accesscontrol_02,Media Group B,,"<p>Access group B for media tests</p>",

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-accessterms.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-accessterms.csv
@@ -1,3 +1,3 @@
-unique_id,name,parent,description
+local_id,name,parent,description
 media_accesscontrol_01,Media Group A,,"<p>Access group A for media tests</p>",
 media_accesscontrol_02,Media Group B,,"<p>Access group B for media tests</p>",

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-audio.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-audio.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,original_name,mime_type,media_of,media_use,url
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url
 media_audio_00001,Moo Cow,Media Group A||Media Group B,moo.mp3,audio/mpeg,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/audio/moo.mp3

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-document.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-document.csv
@@ -1,3 +1,3 @@
-local_id,name,access_terms,original_name,mime_type,media_of,media_use,url
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url
 media_doc_00001,Fuji Acros Datasheet,Media Group A||Media Group B,Fuji_acros.pdf,application/pdf,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf
 media_doc_00002,Fuji Acros Datasheet,Media Group A||Media Group B,Fuji_acros.pdf,application/pdf,:::Media Migration Repository Item Two,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,mime_type,media_of,media_use,url
+unique_id,name,access_terms,mime_type,media_of,media_use,url
 media_ext_00001,Hello World,Media Group A||Media Group B,text/plain,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/extracted_text/hello_world.txt

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-file.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-file.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,original_name,mime_type,media_of,media_use,url
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url
 media_file_00001,Geo Tif file,Media Group A||Media Group B,NEFF1851_GEO.tfw,application/octet-stream,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/file/NEFF1851_GEO.tfw

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-image.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-image.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,original_name,mime_type,media_of,media_use,url,alt_text
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,alt_text
 media_img_00001,Looking For Fossils,Media Group A||Media Group B,TRP_7767.jpg,image/jpeg,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/image/TRP_7767.jpg,Image alt text

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-remote_video.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-remote_video.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,media_of,url
+unique_id,name,access_terms,media_of,url
 media_rvideo_00001,A Tour of Go,Media Group A|Media Group B,:::Media Migration Repository Item One,https://www.youtube.com/watch?v=ytEkHepK08c

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-video.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-video.csv
@@ -1,2 +1,2 @@
-local_id,name,access_terms,original_name,mime_type,media_of,media_use,url
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url
 media_video_00001,Chair Pop Video,Media Group A||Media Group B,chair-pop-gif.mp4,video/mp4,:::Media Migration Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/video/chair-pop-gif.mp4

--- a/tests/11-file-deletion-tests/testcafe/migrations/filedeletion-file.csv
+++ b/tests/11-file-deletion-tests/testcafe/migrations/filedeletion-file.csv
@@ -1,2 +1,2 @@
-local_id,name,original_name,mime_type,media_of,media_use,url
+unique_id,name,original_name,mime_type,media_of,media_use,url
 deletion_file_00001,Test Geo Tif File,NEFF1851_GEO.tfw,application/octet-stream,:::File Deletion Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/file/NEFF1851_GEO.tfw

--- a/tests/12-media-tests/testcafe/migrate_derivative.spec.js
+++ b/tests/12-media-tests/testcafe/migrate_derivative.spec.js
@@ -69,3 +69,26 @@ test('Migrate Images for Derivative Generation', async t => {
     await t.expect(thumb_derivative.count).eql(1);
     await t.expect(fits_derivative.count).eql(1);
 });
+
+test('Test Derivatives Unique Id Field', async t => {
+
+    // note: FITS media do not have this field.
+    const media_list = ['Service File.jpg', 'Thumbnail Image.jpg'];
+    const io_name = "Derivative Repository Item One"
+
+    // we know these derivatives already exist from last test, so don't repeat those
+    // tests here, just look at deriviatives
+    for (const media_text of media_list) {
+      await t.navigateTo(contentList);
+      const io = Selector('div.view-content').find('a').withText(io_name);
+      await t.click(io);
+      await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'));
+
+      const derivative = Selector('div.view-content').find('a').withText(media_text);
+
+      // just make sure they each have a value for unique id field set.
+      await t.click(derivative);
+      await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Edit'));
+      await t.expect(Selector('#edit-field-unique-id-0-value').value).notEql('');
+    }
+});

--- a/tests/12-media-tests/testcafe/migrations/derivative-file.csv
+++ b/tests/12-media-tests/testcafe/migrations/derivative-file.csv
@@ -1,2 +1,2 @@
-local_id,name,original_name,mime_type,media_of,media_use,url
+unique_id,name,original_name,mime_type,media_of,media_use,url
 derivative_media_file_00001,Map Image,map-image.tif,image/tiff,:::Derivative Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/image/map-image.tif

--- a/tests/12-media-tests/testcafe/migrations/media-format-file.csv
+++ b/tests/12-media-tests/testcafe/migrations/media-format-file.csv
@@ -1,4 +1,4 @@
-local_id,name,original_name,mime_type,media_of,media_use,url
+unique_id,name,original_name,mime_type,media_of,media_use,url
 media_format_file_tests_01,Geo Tif file,NEFF1851_GEO.tfw,application/octet-stream,:::Migrated Geo Tiff Object,Original File,http://migration-assets/assets/file/NEFF1851_GEO.tfw
 media_format_file_tests_02,Test Zip File,file_test.zip,application/zip,:::Migrated Zip Object,Original File,http://migration-assets/assets/file/file_test.zip
 media_format_file_tests_03,Test Tar File,file_test.tar,application/x-tar,:::Migrated Tar Object,Original File,http://migration-assets/assets/file/file_test.tar

--- a/tests/12-media-tests/testcafe/migrations/media-format-image.csv
+++ b/tests/12-media-tests/testcafe/migrations/media-format-image.csv
@@ -1,3 +1,3 @@
-local_id,name,original_name,mime_type,media_of,media_use,url,alt_text
+unique_id,name,original_name,mime_type,media_of,media_use,url,alt_text
 media_format_file_tiff_01,Tiff Image,tiff.tif,image/tiff,:::Migrated Tiff Object,Original File,http://migration-assets/assets/image/formats/tiff.tif,tiff
 media_format_file_tiff_02,Jpeg 2000 Image,jp2.jp2,image/jp2,:::Migrated JPEG2000 Object,Original File,http://migration-assets/assets/image/formats/jp2.jp2,jp2


### PR DESCRIPTION
Resolves https://github.com/jhu-idc/iDC-general/issues/385 by adding field_unique_id to media as well.  

To test this PR create a Repo Item and add some media to it. Ensure that the field is there and required. Ensure that any media generated also get a unique id applied to them. 

This adds a test that does a quick check to see that the derivatives for an image do get a unique id on them (service file and thumbnail). 