### PR TITLE
Removes the large file derivatives test suite from the main CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
               - 13-migration-entity-resolution
               - 20-export-tests
               - 21-role-permission-tests
-              - 21-large-file-derivatives
           fail-fast: false
         steps:
             # Check out current commit


### PR DESCRIPTION
The test suite will still run in the nightly workflow.