### PR TITLE
Fixes a few csv files that had local_id in them

### DIFF
--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-documents.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-documents.csv
@@ -1,2 +1,2 @@
-local_id,node_id,name,original_name,mime_type,media_of,media_use,url
-lfs_doc_00001,,Fuji Acros Datasheet,Fuji_acros.pdf,application/pdf,:::Derivative Documents,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf
+unique_id,name,original_name,mime_type,media_of,media_use,url
+lfs_doc_00001,Fuji Acros Datasheet,Fuji_acros.pdf,application/pdf,:::Derivative Documents,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-images.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-images.csv
@@ -1,7 +1,7 @@
-local_id,node_id,name,original_name,mime_type,media_of,media_use,url
-lfs_image_00001,,B12.tiff,B12.tiff,image/tiff,:::Derivative Image 01,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B12.tiff
-lfs_image_00002,,B13.tiff,B13.tiff,image/tiff,:::Derivative Image 02,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B13.tiff
-lfs_image_00003,,B14.tiff,B14.tiff,image/tiff,:::Derivative Image 03,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B14.tiff
-lfs_image_00004,,B15.tiff,B15.tiff,image/tiff,:::Derivative Image 04,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B15.tiff
-lfs_image_00005,,NEFF1851.tiff,NEFF1851.tiff,image/tiff,:::Derivative Image 05,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/NEFF1851.tiff
+unique_id,name,original_name,mime_type,media_of,media_use,url
+lfs_image_00001,B12.tiff,B12.tiff,image/tiff,:::Derivative Image 01,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B12.tiff
+lfs_image_00002,B13.tiff,B13.tiff,image/tiff,:::Derivative Image 02,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B13.tiff
+lfs_image_00003,B14.tiff,B14.tiff,image/tiff,:::Derivative Image 03,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B14.tiff
+lfs_image_00004,B15.tiff,B15.tiff,image/tiff,:::Derivative Image 04,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B15.tiff
+lfs_image_00005,NEFF1851.tiff,NEFF1851.tiff,image/tiff,:::Derivative Image 05,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/NEFF1851.tiff
 

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-video.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-video.csv
@@ -1,2 +1,2 @@
-local_id,node_id,name,original_name,mime_type,media_of,media_use,url
-lfs_video_00002,,smptebars2.mp4,smptebars2.mp4,video/mp4,:::Derivative Large Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars2.mp4
+unique_id,name,original_name,mime_type,media_of,media_use,url
+lfs_video_00002,smptebars2.mp4,smptebars2.mp4,video/mp4,:::Derivative Large Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars2.mp4

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-small-video.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-small-video.csv
@@ -1,2 +1,2 @@
-local_id,node_id,name,original_name,mime_type,media_of,media_use,url
-lfs_video_00001,,smptebars.mp4,smptebars.mp4,video/mp4,:::Derivative Small Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars.mp4
+unique_id,name,original_name,mime_type,media_of,media_use,url
+lfs_video_00001,smptebars.mp4,smptebars.mp4,video/mp4,:::Derivative Small Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars.mp4


### PR DESCRIPTION
Because I was able to merge w/o rebasing my other PRs, I missed a few spots that were newly added via other PRs. 

This should fix the nightly run of large file derivative tests. 