### PR TITLE
Ignore Drupal system and module update error messages

### DIFF
--- a/tests/10-migration-backend-tests/testcafe/util.js
+++ b/tests/10-migration-backend-tests/testcafe/util.js
@@ -124,9 +124,11 @@ export const doMigration = async (t, migrationType, file) => {
         // Something failed and was kind enough to leave a message
         if (error_count > 0) {
           let error_msg_count = await Selector(".messages--error").find(".messages__list").count;
+          // We need to ignore messages for Drupal security updates as well as module security updates
+          // which are formatted slightly differently
           let update_warning_present = await Selector(".messages--error")
             .find(".messages__list")
-            .withText("There is a security update available for your version of Drupal.").count;
+            .withText("security update").count;
 
           console.log("error message count: ", error_msg_count);
           if (update_warning_present == 0 || update_warning_present == 1 && error_msg_count > 1) {

--- a/tests/12-media-tests/testcafe/util.js
+++ b/tests/12-media-tests/testcafe/util.js
@@ -126,7 +126,7 @@ export const doMigration = async (t, migrationType, file) => {
           let error_msg_count = await Selector(".messages--error").find(".messages__list").count;
           let update_warning_present = await Selector(".messages--error")
             .find(".messages__list")
-            .withText("There is a security update available for your version of Drupal.").count;
+            .withText("security update").count;
 
           console.log("error message count: ", error_msg_count);
           if (update_warning_present == 0 || update_warning_present == 1 && error_msg_count > 1) {

--- a/tests/20-export-tests/testcafe/util.js
+++ b/tests/20-export-tests/testcafe/util.js
@@ -122,7 +122,7 @@ export const doMigration = async (t, migrationType, file) => {
           let error_msg_count = await Selector(".messages--error").find(".messages__list").count;
           let update_warning_present = await Selector(".messages--error")
             .find(".messages__list")
-            .withText("There is a security update available for your version of Drupal.").count;
+            .withText("security update").count;
 
           if (update_warning_present == 0 || update_warning_present == 1 && error_msg_count > 1) {
             throw "Error performing migrations!";


### PR DESCRIPTION
A previous commit had explicitly ignore Drupal system message update error messages. This PR changes the text that is looked for in error messages in order to accommodate module update error messages and other security update error messages as well.