### PR TITLE
Loosen selector timeouts for migrations in end to end tests

### DIFF
--- a/end-to-end/tests/admin/s3.spec.js
+++ b/end-to-end/tests/admin/s3.spec.js
@@ -27,7 +27,7 @@ test('Verify original file and derivatives are in S3', async t => {
     await migrate(t, 'idc_ingest_taxonomy_subject', '../testdata/s3/subject.csv');
     await migrate(t, migrate_new_collection, '../testdata/s3/s3-collection.csv');
     await migrate(t, migrate_new_items, '../testdata/s3/s3-islandora_object.csv');
-    await migrate(t, migrate_media_image, '../testdata/s3/s3-file.csv');
+    await migrate(t, migrate_media_image, '../testdata/s3/s3-file.csv', 30000);
 
     // verify the presence of the islandora object
     const io_name = "S3 Repository Item 1"

--- a/end-to-end/tests/helpers.js
+++ b/end-to-end/tests/helpers.js
@@ -60,6 +60,7 @@ export async function migrate(t, migrationId, sourceFile, timeout = 10000) {
   const fileInput = Selector('#edit-source-file');
 
   await t
+    .expect(sourceFile).ok('No file path was provided')
     .click(selectMigration)
     .click(migrationOptions.withAttribute('value', migrationId))
     .setFilesToUpload(fileInput, [ sourceFile ])

--- a/end-to-end/tests/ui/data-migrations.js
+++ b/end-to-end/tests/ui/data-migrations.js
@@ -138,7 +138,7 @@ async function checkForUIMigrations(t) {
 
 test('Do migrations', async (t) => {
   if (!(await checkForUIMigrations(t))) {
-    await addUiData(t);
+    await addUiData(t, 30000);
   }
 });
 


### PR DESCRIPTION
The earlier `ui-tests` PR passed its tests in the PR, but once merged the new tip of `development` failed its tests consistently after a couple of reruns. The test failure on `development` failed during end-to-end test image csv migrations. The migrations look for a status message containing the migration ID with the string "0 failed", but according to the "error" screenshot produced by Testcafe, this status element is present on the page. I am not sure why it it is failing.

_Testcafe error report screenshot_
![1](https://user-images.githubusercontent.com/5167587/131010949-225c52b9-624e-44c9-bac3-809a3944de63.png)

I was able to recreate the test failure in the development branch of a fork of this repo. When I applied this code change to that branch it was able to pass. With the way the CI tests were behaving, I'm not quite convinced that this will "fix" the tests here, though.