### PR TITLE
Changes words "Preservation Master File" to "Preservation File"

### DIFF
--- a/.env
+++ b/.env
@@ -73,7 +73,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 TAG=upstream-20200824-f8d1e8e-49-g0bd56b6
 
 # Docker image and tag for snapshot image
-SNAPSHOT_TAG=upstream-20201007-739693ae-375-g418083a.1629147796
+SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me

--- a/codebase/config/sync/views.view.display_media.yml
+++ b/codebase/config/sync/views.view.display_media.yml
@@ -193,7 +193,7 @@ display:
   entity_view_1:
     display_plugin: entity_view
     id: entity_view_1
-    display_title: 'Preservation Master - Download'
+    display_title: 'Preservation File - Download'
     position: 1
     display_options:
       display_extenders: {  }
@@ -220,7 +220,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: 'http://pcdm.org/use#PreservationMasterFile'
+          value: 'http://pcdm.org/use#PreservationFile'
           group: 1
           exposed: false
           expose:
@@ -229,6 +229,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -236,8 +238,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -262,7 +262,7 @@ display:
       bundles: {  }
       argument_mode: id
       default_argument: null
-      title: 'Preservation Master'
+      title: 'Preservation File'
       show_title: false
     cache_metadata:
       max-age: -1

--- a/codebase/config/sync/views.view.openseadragon_media_evas.yml
+++ b/codebase/config/sync/views.view.openseadragon_media_evas.yml
@@ -293,7 +293,7 @@ display:
   entity_view_2:
     display_plugin: entity_view
     id: entity_view_2
-    display_title: 'Preservation Master'
+    display_title: 'Preservation File'
     position: 1
     display_options:
       display_extenders: {  }
@@ -320,7 +320,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: 'http://pcdm.org/use#PreservationMasterFile'
+          value: 'http://pcdm.org/use#PreservationFile'
           group: 1
           exposed: false
           expose:
@@ -329,6 +329,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -336,8 +338,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -364,7 +364,7 @@ display:
       bundles: {  }
       argument_mode: id
       default_argument: null
-      title: 'OpenSeadragon - Preservation Master'
+      title: 'OpenSeadragon - Preservation File'
       show_title: false
       style:
         type: default

--- a/codebase/config/sync/views.view.pdfjs_media_evas.yml
+++ b/codebase/config/sync/views.view.pdfjs_media_evas.yml
@@ -288,7 +288,7 @@ display:
   entity_view_2:
     display_plugin: entity_view
     id: entity_view_2
-    display_title: 'Preservation Master'
+    display_title: 'Preservation File'
     position: 1
     display_options:
       display_extenders: {  }
@@ -315,7 +315,7 @@ display:
           group_type: group
           admin_label: ''
           operator: '='
-          value: 'http://pcdm.org/use#PreservationMasterFile'
+          value: 'http://pcdm.org/use#PreservationFile'
           group: 1
           exposed: false
           expose:
@@ -324,6 +324,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -331,8 +333,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -359,7 +359,7 @@ display:
       bundles: {  }
       argument_mode: id
       default_argument: null
-      title: 'PDFjs - Preservation Master'
+      title: 'PDFjs - Preservation File'
       show_title: false
       style:
         type: default

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-audio.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-audio.csv
@@ -1,2 +1,2 @@
 unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access
-media_audio_00001,Moo Cow,:::media_accesscontrol_01||:::media_accesscontrol_02,moo.mp3,audio/mpeg,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/audio/moo.mp3,1
+media_audio_00001,Moo Cow,:::media_accesscontrol_01||:::media_accesscontrol_02,moo.mp3,audio/mpeg,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/audio/moo.mp3,1

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-document.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-document.csv
@@ -1,3 +1,3 @@
 unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access
-media_doc_00001,Fuji Acros Datasheet,:::media_accesscontrol_01||:::media_accesscontrol_02,Fuji_acros.pdf,application/pdf,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf,0
-media_doc_00002,Fuji Acros Datasheet,:::media_accesscontrol_01||:::media_accesscontrol_02,Fuji_acros.pdf,application/pdf,:::media_io_2,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf,0
+media_doc_00001,Fuji Acros Datasheet,:::media_accesscontrol_01||:::media_accesscontrol_02,Fuji_acros.pdf,application/pdf,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/document/Fuji_acros.pdf,0
+media_doc_00002,Fuji Acros Datasheet,:::media_accesscontrol_01||:::media_accesscontrol_02,Fuji_acros.pdf,application/pdf,:::media_io_2,Original File||Preservation File,http://migration-assets/assets/document/Fuji_acros.pdf,0

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text.csv
@@ -1,2 +1,2 @@
 unique_id,name,access_terms,mime_type,media_of,media_use,url,restricted_access
-media_ext_00001,Hello World,:::media_accesscontrol_01||:::media_accesscontrol_02,text/plain,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/extracted_text/hello_world.txt,1
+media_ext_00001,Hello World,:::media_accesscontrol_01||:::media_accesscontrol_02,text/plain,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/extracted_text/hello_world.txt,1

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-file.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-file.csv
@@ -1,2 +1,2 @@
 unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access
-media_file_00001,Geo Tif file,:::media_accesscontrol_01||:::media_accesscontrol_02,NEFF1851_GEO.tfw,application/octet-stream,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/file/NEFF1851_GEO.tfw,1
+media_file_00001,Geo Tif file,:::media_accesscontrol_01||:::media_accesscontrol_02,NEFF1851_GEO.tfw,application/octet-stream,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/file/NEFF1851_GEO.tfw,1

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-image.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-image.csv
@@ -1,3 +1,3 @@
 unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,alt_text,restricted_access
-media_img_00001,Looking For Fossils,:::media_accesscontrol_01||:::media_accesscontrol_02,TRP_7767.jpg,image/jpeg,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/image/TRP_7767.jpg,Image alt text,0
+media_img_00001,Looking For Fossils,:::media_accesscontrol_01||:::media_accesscontrol_02,TRP_7767.jpg,image/jpeg,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/image/TRP_7767.jpg,Image alt text,0
 media_format_file_tiff_01,Tiff Image,:::media_accesscontrol_01||:::media_accesscontrol_02,tiff.tif,image/tiff,::title:Migrated Tiff Object,Original File,http://migration-assets/assets/image/formats/tiff.tif,tiff,1

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-video.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-video.csv
@@ -1,2 +1,2 @@
 unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access
-media_video_00001,Chair Pop Video,:::media_accesscontrol_01||:::media_accesscontrol_02,chair-pop-gif.mp4,video/mp4,:::media_io_1,Original File||Preservation Master File,http://migration-assets/assets/video/chair-pop-gif.mp4,1
+media_video_00001,Chair Pop Video,:::media_accesscontrol_01||:::media_accesscontrol_02,chair-pop-gif.mp4,video/mp4,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/video/chair-pop-gif.mp4,1

--- a/tests/10-migration-backend-tests/verification/expected/media-audio.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-audio.json
@@ -8,7 +8,7 @@
   "mime_type": "audio/mpeg",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/10-migration-backend-tests/verification/expected/media-document.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-document.json
@@ -8,7 +8,7 @@
   "mime_type": "application/pdf",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/10-migration-backend-tests/verification/expected/media-extracted_text.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-extracted_text.json
@@ -8,7 +8,7 @@
   "mime_type": "text/plain",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/10-migration-backend-tests/verification/expected/media-file.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-file.json
@@ -8,7 +8,7 @@
   "mime_type": "application/octet-stream",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/10-migration-backend-tests/verification/expected/media-image.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-image.json
@@ -11,7 +11,7 @@
   "mime_type": "image/jpeg",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/10-migration-backend-tests/verification/expected/media-video.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-video.json
@@ -8,7 +8,7 @@
   "mime_type": "video/mp4",
   "restricted_access": true,
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "access_terms": [

--- a/tests/11-file-deletion-tests/testcafe/migrations/filedeletion-file.csv
+++ b/tests/11-file-deletion-tests/testcafe/migrations/filedeletion-file.csv
@@ -1,2 +1,2 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-deletion_file_00001,Test Geo Tif File,NEFF1851_GEO.tfw,application/octet-stream,::title:File Deletion Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/file/NEFF1851_GEO.tfw
+deletion_file_00001,Test Geo Tif File,NEFF1851_GEO.tfw,application/octet-stream,::title:File Deletion Repository Item One,Original File||Preservation File,http://migration-assets/assets/file/NEFF1851_GEO.tfw

--- a/tests/12-media-tests/testcafe/migrate_derivative.spec.js
+++ b/tests/12-media-tests/testcafe/migrate_derivative.spec.js
@@ -43,7 +43,7 @@ test('Migrate Images for Derivative Generation', async t => {
     // assert expected attributes of the original media
     await t.expect(media.parent('tr').child('td').nth(2).innerText).eql('Image')
     await t.expect(media.parent('tr').child('td').nth(3).innerText).eql('image/tiff')
-    await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Preservation Master File')
+    await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Preservation File')
     await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Original File')
 
     // assert the presence of a derivative thumbnail and service image

--- a/tests/12-media-tests/testcafe/migrations/derivative-file.csv
+++ b/tests/12-media-tests/testcafe/migrations/derivative-file.csv
@@ -1,2 +1,2 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-derivative_media_file_00001,Map Image,map-image.tif,image/tiff,::title:Derivative Repository Item One,Original File||Preservation Master File,http://migration-assets/assets/image/map-image.tif
+derivative_media_file_00001,Map Image,map-image.tif,image/tiff,::title:Derivative Repository Item One,Original File||Preservation File,http://migration-assets/assets/image/map-image.tif

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-documents.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-documents.csv
@@ -1,2 +1,2 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-lfs_doc_00001,Fuji Acros Datasheet,Fuji_acros.pdf,application/pdf,::title:Derivative Documents,Original File||Preservation Master File,http://migration-assets/assets/document/Fuji_acros.pdf
+lfs_doc_00001,Fuji Acros Datasheet,Fuji_acros.pdf,application/pdf,::title:Derivative Documents,Original File||Preservation File,http://migration-assets/assets/document/Fuji_acros.pdf

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-images.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-images.csv
@@ -1,6 +1,6 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-lfs_image_00001,B12.tiff,B12.tiff,image/tiff,::title:Derivative Image 01,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B12.tiff
-lfs_image_00002,B13.tiff,B13.tiff,image/tiff,::title:Derivative Image 02,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B13.tiff
-lfs_image_00003,B14.tiff,B14.tiff,image/tiff,::title:Derivative Image 03,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B14.tiff
-lfs_image_00004,B15.tiff,B15.tiff,image/tiff,::title:Derivative Image 04,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/B15.tiff
-lfs_image_00005,NEFF1851.tiff,NEFF1851.tiff,image/tiff,::title:Derivative Image 05,Original File||Preservation Master File,http://migration-assets/assets/lfs/image/NEFF1851.tiff
+lfs_image_00001,B12.tiff,B12.tiff,image/tiff,::title:Derivative Image 01,Original File||Preservation File,http://migration-assets/assets/lfs/image/B12.tiff
+lfs_image_00002,B13.tiff,B13.tiff,image/tiff,::title:Derivative Image 02,Original File||Preservation File,http://migration-assets/assets/lfs/image/B13.tiff
+lfs_image_00003,B14.tiff,B14.tiff,image/tiff,::title:Derivative Image 03,Original File||Preservation File,http://migration-assets/assets/lfs/image/B14.tiff
+lfs_image_00004,B15.tiff,B15.tiff,image/tiff,::title:Derivative Image 04,Original File||Preservation File,http://migration-assets/assets/lfs/image/B15.tiff
+lfs_image_00005,NEFF1851.tiff,NEFF1851.tiff,image/tiff,::title:Derivative Image 05,Original File||Preservation File,http://migration-assets/assets/lfs/image/NEFF1851.tiff

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-video.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-large-video.csv
@@ -1,2 +1,2 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-lfs_video_00002,smptebars2.mp4,smptebars2.mp4,video/mp4,::title:Derivative Large Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars2.mp4
+lfs_video_00002,smptebars2.mp4,smptebars2.mp4,video/mp4,::title:Derivative Large Video,Original File||Preservation File,http://migration-assets/assets/lfs/video/smptebars2.mp4

--- a/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-small-video.csv
+++ b/tests/21-large-file-derivatives-nightly/testcafe/migrations/lfs-media-small-video.csv
@@ -1,2 +1,2 @@
 unique_id,name,original_name,mime_type,media_of,media_use,url
-lfs_video_00001,smptebars.mp4,smptebars.mp4,video/mp4,::title:Derivative Small Video,Original File||Preservation Master File,http://migration-assets/assets/lfs/video/smptebars.mp4
+lfs_video_00001,smptebars.mp4,smptebars.mp4,video/mp4,::title:Derivative Small Video,Original File||Preservation File,http://migration-assets/assets/lfs/video/smptebars.mp4

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-original.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-original.json
@@ -3,7 +3,7 @@
   "bundle": "document",
   "name": "Fuji Acros Datasheet",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Documents"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-01.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-01.json
@@ -3,7 +3,7 @@
   "bundle": "image",
   "name": "B12.tiff",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Image 01"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-02.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-02.json
@@ -3,7 +3,7 @@
   "bundle": "image",
   "name": "B13.tiff",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Image 02"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-03.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-03.json
@@ -3,7 +3,7 @@
   "bundle": "image",
   "name": "B14.tiff",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Image 03"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-04.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-04.json
@@ -3,7 +3,7 @@
   "bundle": "image",
   "name": "B15.tiff",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Image 04"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-05.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-image-original-05.json
@@ -3,7 +3,7 @@
   "bundle": "image",
   "name": "NEFF1851.tiff",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Image 05"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-largevideo-original.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-largevideo-original.json
@@ -3,7 +3,7 @@
   "bundle": "video",
   "name": "smptebars.mp4",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Large Video"

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-smallvideo-original.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-smallvideo-original.json
@@ -3,7 +3,7 @@
   "bundle": "video",
   "name": "smptebars2.mp4",
   "use": [
-    "Preservation Master File",
+    "Preservation File",
     "Original File"
   ],
   "media_of": "Derivative Small Video"


### PR DESCRIPTION
**This updates the snapshot** 

Resolves https://github.com/jhu-idc/iDC-general/issues/362
This change removes the word "Master" from "Preservation Master File" where ever it's found in our current configuration. 
Specifically, this updates 
  - a few EVA views that have the PCDM link to Preservation Master File in them. 
  - the snapshot so the Media Use taxonomy term name and link are update as well. 

In thinking about installing from scratch (ie, no snapshot) -- note that this doesn't update the yml config files for these views inside the islandora_defaults module (config/install) itself.  We can update them there, but then there's still the migration data itself which is brought in from a migration located in the islandora module (migration/tags.csv), which is not so easy to update right now (unless we fork it).  I left updating the modules themselves alone for now, but can change this if it's desired.
