### PR TITLE
Revert content-based filenames

### DIFF
--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
@@ -20,6 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -45,18 +47,22 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
       - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +86,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
@@ -20,6 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -45,18 +47,21 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
-      - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +85,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
@@ -21,6 +21,8 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
     FORMAT: basic_html
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -46,18 +48,21 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
-      - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +85,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
@@ -20,6 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -45,18 +47,21 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
-      - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +85,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
@@ -20,6 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -45,18 +47,21 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
-      - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +85,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
@@ -20,6 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
+    DATE_FORMAT: 'Y-m-d'
+    DIR_DELIMITER: '/'
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -45,18 +47,22 @@ process:
       - url
       - '@_url_filepath'
     file_exists: 1
-  _file_sha:
+  _formatted_date:
     plugin: callback
-    callable: sha1_file
-    source: '@_download_filepath'
-  _destination_filepath:
-    plugin: pairtree
-    source: '@_file_sha'
+    callable: date
+    source: constants/DATE_FORMAT
+  _destination_dir:
+    plugin: concat
+    source:
+      - '@_formatted_date'
+      - constants/DIR_DELIMITER
   _destination_drupalpath:
     plugin: concat
     source:
       - constants/DRUPAL_FS
-      - '@_destination_filepath'
+      - '@_destination_dir'
+      - '@_url_filename'
+
   field_access_terms:
     -
       plugin: skip_on_empty
@@ -80,7 +86,8 @@ process:
     uid: constants/ADMIN
     move: true
     reuse: false
-    rename: false
+    file_exists: rename
+    rename: true
     id_only: true
     destination: '@_destination_drupalpath'
     mimetype: mime_type

--- a/tests/10-migration-backend-tests/verification/expected/media-audio.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-audio.json
@@ -15,9 +15,5 @@
     "Media Group B",
     "Media Group A"
   ],
-  "media_of": "Media Migration Repository Item One",
-  "uri": {
-    "url": "/system/files/76/6d/51/a112896d48d3457fb3c5fa5fbdf661713d",
-    "value": "private://76/6d/51/a112896d48d3457fb3c5fa5fbdf661713d"
-  }
+  "media_of": "Media Migration Repository Item One"
 }

--- a/tests/10-migration-backend-tests/verification/expected/media-document.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-document.json
@@ -15,9 +15,5 @@
     "Media Group B",
     "Media Group A"
   ],
-  "media_of": "Media Migration Repository Item One",
-  "uri": {
-    "url": "/system/files/c9/a0/60/c39365820edc5d1a51f221d49e96a8a730",
-    "value": "private://c9/a0/60/c39365820edc5d1a51f221d49e96a8a730"
-  }
+  "media_of": "Media Migration Repository Item One"
 }

--- a/tests/10-migration-backend-tests/verification/expected/media-extracted_text.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-extracted_text.json
@@ -16,10 +16,6 @@
     "Media Group A"
   ],
   "media_of": "Media Migration Repository Item One",
-  "uri": {
-    "url": "/system/files/53/06/43/aaed48b24d41bbe075579df620204d06d1",
-    "value": "private://53/06/43/aaed48b24d41bbe075579df620204d06d1"
-  },
   "extracted_text": {
     "value": "Hello, extracted text world!<br />\n",
     "format": "basic_html",

--- a/tests/10-migration-backend-tests/verification/expected/media-file.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-file.json
@@ -15,9 +15,5 @@
     "Media Group B",
     "Media Group A"
   ],
-  "media_of": "Media Migration Repository Item One",
-  "uri": {
-    "url": "/system/files/2b/ad/93/5635dd338a834b391d8497bb02620341fa",
-    "value": "private://2b/ad/93/5635dd338a834b391d8497bb02620341fa"
-  }
+  "media_of": "Media Migration Repository Item One"
 }

--- a/tests/10-migration-backend-tests/verification/expected/media-video.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-video.json
@@ -15,9 +15,5 @@
     "Media Group B",
     "Media Group A"
   ],
-  "media_of": "Media Migration Repository Item One",
-  "uri": {
-    "url": "/system/files/34/e9/34/86f9a355930ac2c14f067082e6d584ea24",
-    "value": "private://34/e9/34/86f9a355930ac2c14f067082e6d584ea24"
-  }
+  "media_of": "Media Migration Repository Item One"
 }

--- a/tests/10-migration-backend-tests/verification/go.mod
+++ b/tests/10-migration-backend-tests/verification/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/jhu-idc/idc-golang v0.0.6
+	github.com/jhu-idc/idc-golang v0.0.7
 	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/tests/10-migration-backend-tests/verification/go.sum
+++ b/tests/10-migration-backend-tests/verification/go.sum
@@ -13,6 +13,8 @@ github.com/jhu-idc/idc-golang v0.0.5 h1:hsO2u+WbWjaSAacYgGqqNodak+Rfilr4+0i8tzwU
 github.com/jhu-idc/idc-golang v0.0.5/go.mod h1:wxcDQrMEPBHa1dPsZCXaAdR1lAUbiY4NuzP/lSMEskg=
 github.com/jhu-idc/idc-golang v0.0.6 h1:rnItIioFXmlUERx/n9f+r+ZZSjxiWQmQItslTAMS2C0=
 github.com/jhu-idc/idc-golang v0.0.6/go.mod h1:wxcDQrMEPBHa1dPsZCXaAdR1lAUbiY4NuzP/lSMEskg=
+github.com/jhu-idc/idc-golang v0.0.7 h1:8uoKpil585HsSSARr2/njsUdZ6IQ+FO7uf2B7uPrsIo=
+github.com/jhu-idc/idc-golang v0.0.7/go.mod h1:wxcDQrMEPBHa1dPsZCXaAdR1lAUbiY4NuzP/lSMEskg=
 github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
 github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Updates migrations to import files using their names, rather than using sha hashes.

Closes jhu-idc/iDC-general#412