### PR TITLE
Bugfix for Featured Items

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8105,12 +8105,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "317441cd7d0f19492c1bd38bd48d5b6001a07588"
+                "reference": "beb230418367bcd2c19649b52747c8a2bd92611b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/317441cd7d0f19492c1bd38bd48d5b6001a07588",
-                "reference": "317441cd7d0f19492c1bd38bd48d5b6001a07588",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/beb230418367bcd2c19649b52747c8a2bd92611b",
+                "reference": "beb230418367bcd2c19649b52747c8a2bd92611b",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8120,7 +8120,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2021-08-25T13:55:29+00:00"
+            "time": "2021-09-09T14:30:57+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",

--- a/end-to-end/tests/ui/collection-details.spec.js
+++ b/end-to-end/tests/ui/collection-details.spec.js
@@ -88,12 +88,12 @@ test('Contact modal displays correctly', async (t) => {
     .expect(Page.contactModal.visibility().exists).notOk();
 });
 
-// TODO: enable once this bug is fixed
-test.skip('Featured repo items display correctly', async (t) => {
+test('Featured repo items display correctly', async (t) => {
   await t
     .expect(Page.featuredItems.list.exists).ok()
     .expect(Page.featuredItems.items.count).eql(2)
-    .expect(Page.featuredItems.items.nth(0).find('image').exists).ok()
-    // Mallard item has a Tiff image, which should never be displayed on the page
-    .expect(Page.featuredItems.items.nth(0).find('image').attributes.src).notContains('.tif');
+    .expect(Page.featuredItems.items.nth(0).find('img').exists).ok()
+    // // Mallard item has a Tiff image, which should never be displayed on the page
+    .expect(Page.featuredItems.items.nth(0).find('img').withAttribute('src', /\.jpg$/).exists).ok()
+    .expect(Page.featuredItems.items.nth(1).withText('No image available').exists).ok();
 });

--- a/end-to-end/tests/ui/pages/collection-details.js
+++ b/end-to-end/tests/ui/pages/collection-details.js
@@ -1,6 +1,7 @@
 import { Selector, t } from "testcafe";
 import { Searchable } from './searchable';
 import ContactModal from "./contact-modal";
+import FeaturedItems from "./featured-items-list";
 
 /**
  * The collections details page has all the features of the /collections
@@ -31,6 +32,8 @@ export class CollectionDetails extends Searchable {
     this.facetCategories = facetsContainer.child('[data-test-facets-category]');
 
     this.contactModal = ContactModal;
+
+    this.featuredItems = FeaturedItems;
   }
 
   async toggleMetadata() {

--- a/end-to-end/tests/ui/pages/collections-list.js
+++ b/end-to-end/tests/ui/pages/collections-list.js
@@ -1,20 +1,12 @@
 import { Selector } from 'testcafe';
 import { Searchable } from "./searchable";
-
-class FeaturedItems {
-  constructor() {
-    this.list = Selector('#featured-items');
-
-    this.title = this.list.find('h3');
-    this.items = this.list.find('[data-test-featured-item]');
-  }
-}
+import FeaturedItems from './featured-items-list';
 
 export class CollectionsList extends Searchable {
   constructor() {
     super();
 
-    this.featuredItems = new FeaturedItems();
+    this.featuredItems = FeaturedItems;
   }
 }
 

--- a/end-to-end/tests/ui/pages/featured-items-list.js
+++ b/end-to-end/tests/ui/pages/featured-items-list.js
@@ -1,0 +1,12 @@
+import { Selector } from 'testcafe';
+
+export class FeaturedItems {
+  constructor() {
+    this.list = Selector('#featured-items');
+
+    this.title = this.list.find('h3');
+    this.items = this.list.find('[data-test-featured-item]');
+  }
+}
+
+export default new FeaturedItems();


### PR DESCRIPTION
* Fix possible duplicate thumbnails 
* Fix thumbnails for Tiffs
* Add some simple tests to check for the above behaviors

If you wish to manually test, you can spin up the system fresh (`make reset` if necessary). Run the end-to-end tests, mostly to run the migrations to get data into the system: `make test test=01-end-to-end`. Navigate to the "Duck Collection" and you should see 2 featured items, one with a thumbnail and one with no thumbnail.

The first item has a Tiff image associated with it, so the thumbnail should now be shown with the JPG thumbnail derivative. The second item previously duplicated the first thumbnail, but should now be fixed to say "No image available"