### PR TITLE
Adds Islandora Repository Reports module to iDC.

### DIFF
--- a/codebase/composer.json
+++ b/codebase/composer.json
@@ -56,6 +56,10 @@
             "url": "https://github.com/jhu-idc/idc_export.git"
         },
         {
+            "type": "vcs",
+            "url": "https://github.com/jhu-idc/islandora_repository_reports.git"
+        },
+        {
             "type": "package",
             "package": {
                 "name": "citation-style-language/locales",
@@ -128,6 +132,7 @@
         "jhu-idc/idc_export": "dev-main",
         "jhu-idc/idc_ui_module": "dev-main",
         "jhu-idc/islandora_defaults": "dev-8.x-1.x",
+        "jhu-idc/islandora_repository_reports": "dev-main",
         "jhu-idc/migrate_file": "dev-8.x-1.x",
         "jhu_idc/idc_migration": "^2.0",
         "maennchen/zipstream-php": "^2.1",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5146a8ded20966b6ef133d39f9b7ab27",
+    "content-hash": "7b5863aeaaf5ee635f9b24bcc66ebe5f",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -8161,6 +8161,44 @@
                 "source": "https://github.com/jhu-idc/islandora_defaults/tree/8.x-1.x"
             },
             "time": "2021-09-01T14:54:11+00:00"
+        },
+        {
+            "name": "jhu-idc/islandora_repository_reports",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jhu-idc/islandora_repository_reports.git",
+                "reference": "56a0291091585f311909c61ef1e268569fd9fb99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jhu-idc/islandora_repository_reports/zipball/56a0291091585f311909c61ef1e268569fd9fb99",
+                "reference": "56a0291091585f311909c61ef1e268569fd9fb99",
+                "shasum": ""
+            },
+            "default-branch": true,
+            "type": "drupal-module",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Jordan",
+                    "email": "mjordan@sfu.ca",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Drupal 8/9 module that provides a collection of reports on various aspects of an Islandora repository.",
+            "homepage": "https://github.com/jhu-idc/islandora_repository_reports",
+            "keywords": [
+                "Drupal",
+                "Islandora"
+            ],
+            "support": {
+                "issues": "https://github.com/jhu-idc/islandora_repository_reports/issues",
+                "source": "https://github.com/jhu-idc/islandora_repository_reports/tree/main"
+            },
+            "time": "2021-09-10T20:21:16+00:00"
         },
         {
             "name": "jhu-idc/migrate_file",
@@ -21367,6 +21405,7 @@
         "jhu-idc/idc_export": 20,
         "jhu-idc/idc_ui_module": 20,
         "jhu-idc/islandora_defaults": 20,
+        "jhu-idc/islandora_repository_reports": 20,
         "jhu-idc/migrate_file": 20
     },
     "prefer-stable": true,

--- a/codebase/config/sync/block.block.tipsonusingislandorarepositoryreports.yml
+++ b/codebase/config/sync/block.block.tipsonusingislandorarepositoryreports.yml
@@ -1,0 +1,28 @@
+uuid: 1df3cfb1-f72e-4302-9317-d7374e6027c0
+langcode: en
+status: true
+dependencies:
+  module:
+    - islandora_repository_reports
+    - system
+  theme:
+    - seven
+_core:
+  default_config_hash: HkbRPt5r0HyR4VoLaVa2uMxrYaMdr7CXYPt7_si_MPo
+id: tipsonusingislandorarepositoryreports
+theme: seven
+region: content
+weight: 10
+provider: null
+plugin: islandora_repository_reports_tips
+settings:
+  id: islandora_repository_reports_tips
+  label: 'Tips on using Islandora Repository Reports'
+  provider: islandora_repository_reports
+  label_display: visible
+visibility:
+  request_path:
+    id: request_path
+    pages: /admin/reports/islandora_repository_reports
+    negate: false
+    context_mapping: {  }

--- a/codebase/config/sync/core.extension.yml
+++ b/codebase/config/sync/core.extension.yml
@@ -71,6 +71,10 @@ module:
   islandora_iiif: 0
   islandora_image: 0
   islandora_oaipmh: 0
+  islandora_repository_reports: 0
+  islandora_repository_reports_log: 0
+  islandora_repository_reports_oai_usage: 0
+  islandora_repository_reports_vocab: 0
   islandora_search: 0
   islandora_text_extraction: 0
   islandora_text_extraction_defaults: 0

--- a/codebase/config/sync/islandora_repository_reports.settings.yml
+++ b/codebase/config/sync/islandora_repository_reports.settings.yml
@@ -1,0 +1,6 @@
+islandora_repository_reports_randomize_pie_chart_colors: 1
+islandora_repository_reports_pie_or_doughnut: pie
+islandora_repository_reports_cache_report_data: 0
+islandora_repository_reports_bar_chart_color: '#0080ff'
+_core:
+  default_config_hash: V2IugEemzNKw5-nmSiW2gRHmjW3799fYSPWQVfZSCKc

--- a/codebase/config/sync/islandora_repository_reports_oai_usage.settings.yml
+++ b/codebase/config/sync/islandora_repository_reports_oai_usage.settings.yml
@@ -1,0 +1,3 @@
+islandora_repository_reports_oai_usage_endpoint: /oai/request
+_core:
+  default_config_hash: aAIQVZLhWZnMtxx3NvBw4OdJdBOltl1UX1uHh3abe6A


### PR DESCRIPTION
resolves: https://github.com/jhu-idc/iDC-general/issues/374

This PR adds and enables the [Islandora Repository Reports](https://github.com/jhu-idc/islandora_repository_reports) module. 

This module provides some basic (and somewhat rough around the edges) reports.  I forked the module to clean up a couple of reports to match our configuration, because we separated out Collections into their own content type.

Specific changes to reports are: 
  - I changed the name on the `Nodes by Islandora collection`  to `Repository item count by Collection` and made sure it returns the number of direct items w/in a collection. It does not look at collections in a collection.  Before this change it was not working with our config setup very well at all.  Now it reports useful information. 
  - The `Unique values in a node field` report did not work with Entity References, only string fields, so I added Entity References to it, to add more value to our reports.  This does not work with some of our other data types like Authority Link fields or Language Value Pairs.  

Many reports work okay as is, so this is pretty handy to have, overall.  It does leave lots of room for improvement in the future though.  

To test this check out the branch and `make reset`.  Then ingest a bunch of things, the more the better.  After that run some reports located in the Manage->Reports->Islandora Repository Reports page.   Try out the `Repository Item count by Collection` and `Unique values in a node field` report.    Check out other tests as well.  
