### PR TITLE
Download local git repo for dependency on make up/reset

### DIFF
--- a/.env
+++ b/.env
@@ -70,7 +70,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-51-g1f53532
+TAG=upstream-20200824-f8d1e8e-54-g93a2b68
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319


### PR DESCRIPTION
Update buildkit images that changes the `composer install` command to use the `--prefer-install=auto` which downloads the git repositories in any `dev-` dependency. Useful for active development of our custom modules.

The only effect this _should_ have is if you load this PR and run `make reset`, if you poke at a custom module, such as `idc_ui_module` (at `/codebase/web/module/contrib/idc_ui_module/`), you will now see the `.git` directory and will be able to use Git as you may expect in the module.