### PR TITLE
Sort search results by content type by default

### DIFF
--- a/codebase/config/sync/views.view.solr_search_content.yml
+++ b/codebase/config/sync/views.view.solr_search_content.yml
@@ -224,8 +224,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: true
+          order: DESC
+          exposed: false
           expose:
             label: 'Content type'
           plugin_id: search_api

--- a/codebase/config/sync/views.view.solr_search_content.yml
+++ b/codebase/config/sync/views.view.solr_search_content.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_abstract
     - field.storage.node.field_access_rights
-    - field.storage.node.field_access_terms
     - field.storage.node.field_alternative_title
     - field.storage.node.field_citable_url
     - field.storage.node.field_collection_contact_email
@@ -20,11 +19,7 @@ dependencies:
     - field.storage.node.field_date_created
     - field.storage.node.field_date_published
     - field.storage.node.field_description
-    - field.storage.node.field_digital_identifier
     - field.storage.node.field_digital_publisher
-    - field.storage.node.field_display_hints
-    - field.storage.node.field_dspace_identifier
-    - field.storage.node.field_dspace_item_id
     - field.storage.node.field_extent
     - field.storage.node.field_featured_item
     - field.storage.node.field_finding_aid
@@ -33,7 +28,6 @@ dependencies:
     - field.storage.node.field_is_part_of
     - field.storage.node.field_issn
     - field.storage.node.field_item_barcode
-    - field.storage.node.field_jhir
     - field.storage.node.field_language
     - field.storage.node.field_library_catalog_link
     - field.storage.node.field_member_of
@@ -50,15 +44,12 @@ dependencies:
     - search_api.index.default_solr_index
   module:
     - controlled_access_terms
-    - csv_serialization
-    - idc_export
     - idc_ui_module
     - link
     - reference_value_pair
     - rest
     - search_api
     - serialization
-    - views_data_export
 _core:
   default_config_hash: 2NtHk5q6F6Uf40yvQROy8auf4vYMVBZ4TVhcj3z6FKI
 id: solr_search_content
@@ -226,6 +217,18 @@ display:
           fields: {  }
           plugin_id: search_api_fulltext
       sorts:
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: true
+          expose:
+            label: 'Content type'
+          plugin_id: search_api
         search_api_relevance:
           id: search_api_relevance
           table: search_api_index_default_solr_index
@@ -5596,7 +5599,7 @@ display:
       defaults:
         fields: false
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/end-to-end/tests/ui/collections.spec.js
+++ b/end-to-end/tests/ui/collections.spec.js
@@ -66,33 +66,33 @@ test('Proximity search syntax', async (t) => {
  * the ordering has changed.
  */
 test('List option: sort order', async (t) => {
-  const orderValue = 'sort_order=DESC';
+  const orderValue = 'sort_order=ASC';
   await doSearch(t, 'animal');
 
   await t
     .expect(page.results.count).eql(7)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).notOk();
+    .expect(page.results.nth(0).withText('Arctic Animals').exists).ok();
 
   await page.listOptions.sortOrder.setValue(`&${orderValue}`);
 
   await t
     .expect(await getCurrentUrl()).contains(orderValue)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).ok();
+    .expect(page.results.nth(0).withText('Arctic Animals').exists).notOk();
 });
 
 test('List option: sort by', async (t) => {
   const value = 'sort_by=title';
-  await doSearch(t, 'animal');
+  await doSearch(t, 'moo');
 
   await t
-    .expect(page.results.count).eql(7)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).notOk();
+    .expect(page.results.count).eql(4)
+    .expect(page.results.nth(0).withText('Moo').exists).ok();
 
   await page.listOptions.sortBy.setValue(`&${value}`);
 
   await t
     .expect(await getCurrentUrl()).contains(value)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).ok();
+    .expect(page.results.nth(0).withText('Cow Collection').exists).ok();
 });
 
 test('List option: items per page', async (t) => {


### PR DESCRIPTION
resolves https://github.com/jhu-idc/iDC-general/issues/233

This configuration change force search results to be sorted by type (collection_object, islandora_object) first, before relevance, effectively grouping search results by type. If a user is to select a "Sort By" option in the UI, the option will override this behavior. For example, if the user sorts by "title" in the UI, the results will no longer by sorted by type, only by title.

This needs a review to make sure it meets our use case requirement for sorting