### PR TITLE
Page param now reset on most search updates

### DIFF
--- a/codebase/composer.json
+++ b/codebase/composer.json
@@ -123,7 +123,7 @@
         "drush/drush": "^10.0",
         "islandora-rdm/islandora_fits": "dev-master",
         "islandora/carapace": "dev-8.x-3.x",
-        "jhu-idc/idc-ui-theme": "dev-develop",
+        "jhu-idc/idc-ui-theme": "dev-main",
         "jhu-idc/idc_defaults": "dev-main",
         "jhu-idc/idc_export": "dev-main",
         "jhu-idc/idc_ui_module": "dev-main",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5146a8ded20966b6ef133d39f9b7ab27",
+    "content-hash": "a22d407e911c86493352638caaaa3b47",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -8016,26 +8016,26 @@
         },
         {
             "name": "jhu-idc/idc-ui-theme",
-            "version": "dev-develop",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "58479c402e4ee61ac23008ca5e6001007d148b95"
+                "reference": "19ecd0eb490aed275f5e140e99d5b143c9dbc8ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/58479c402e4ee61ac23008ca5e6001007d148b95",
-                "reference": "58479c402e4ee61ac23008ca5e6001007d148b95",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/19ecd0eb490aed275f5e140e99d5b143c9dbc8ca",
+                "reference": "19ecd0eb490aed275f5e140e99d5b143c9dbc8ca",
                 "shasum": ""
             },
             "default-branch": true,
             "type": "drupal-theme",
             "description": "Moo",
             "support": {
-                "source": "https://github.com/jhu-idc/idc-ui-theme/tree/develop",
+                "source": "https://github.com/jhu-idc/idc-ui-theme/tree/main",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-09-14T14:12:49+00:00"
+            "time": "2021-09-16T18:20:14+00:00"
         },
         {
             "name": "jhu-idc/idc_defaults",

--- a/end-to-end/tests/ui/advanced-search.spec.js
+++ b/end-to-end/tests/ui/advanced-search.spec.js
@@ -50,11 +50,15 @@ test('Proximity search and Clear button', async (t) => {
 });
 
 /**
+ * Navigate to results page 3 first
  * Normal search 'animal' (2 results)
+ *  - Displaying any results means that the current page has been reset as expected
  * Normal search 'animal' OR 'page' (5 results)
  */
 test('Normal search', async (t) => {
   await t.expect(Page.results.count).eql(10);
+
+  await Page.pagers[0].goToPage(3);
 
   const term1 = Page.queryTerm(0);
 
@@ -78,6 +82,14 @@ test('Normal search', async (t) => {
 });
 
 test('Collection filter', async (t) => {
+  const pager = Page.pagers[0];
+
+  await pager.goToPage(3);
+
+  await t
+    .expect(Page.results.count).eql(4)
+    .expect(pager.pager.withText('24 of 24 items').exists).ok();
+
   await t
     .typeText(Page.collectionsFilter.input, 'collection', { paste: true})
     .expect(Page.collectionsFilter.suggestions.count).eql(10)
@@ -118,4 +130,21 @@ test('Date filter and basic search', async (t) => {
     .expect(Page.results.count).eql(8)
     .click(Page.clearFilters)
     .expect(Page.results.count).eql(10);
+});
+
+test('Date filter will reset current page', async (t) => {
+  const pager = Page.pagers[0];
+
+  await t.expect(Page.results.count).eql(10);
+  await pager.goToPage(3);
+  await t
+    .expect(Page.results.count).eql(4)
+    .expect(pager.pager.withText('24 of 24 items').exists).ok();
+
+  await t
+    .typeText(Page.dateInput1, '2000', { paste: true })
+    .pressKey('enter')
+    .expect(Page.results.count).eql(5)
+    .expect(pager.pager.withText('5 of 5 items').exists).ok();
+
 });

--- a/end-to-end/tests/ui/pages/searchable.js
+++ b/end-to-end/tests/ui/pages/searchable.js
@@ -9,6 +9,10 @@ class Pager {
     this.prev = this.buttons.nth(0);
     this.next = this.buttons.nth(-1);
   }
+
+  async goToPage(page) {
+    await t.click(this.buttons.withText(String(page)));
+  }
 }
 
 class Dropdown {
@@ -50,6 +54,7 @@ export class Searchable {
    * @param {number} facets (OPTIONAL) expected number of facets. Default: 0
    */
   constructor() {
+    this.titleBar = Selector('[data-test-search-title-bar]');
     this.searchInput = Selector('[data-test-search-input] input');
     this.searchSubmit = Selector('[data-test-search-input] button');
     this.pagers = [ new Pager(0), new Pager(1) ];

--- a/end-to-end/tests/ui/search-page.spec.js
+++ b/end-to-end/tests/ui/search-page.spec.js
@@ -1,0 +1,49 @@
+import Page from './pages/searchable';
+
+fixture `Search Page`
+  .page `https://islandora-idc.traefik.me/search`;
+
+test('Returns all items by default', async (t) => {
+  const pager = Page.pagers[0];
+  await t
+    .expect(Page.titleBar.withText('Search Results').exists).ok()
+    .expect(pager.pager.withText('of 24 items').exists).ok()
+    .expect(pager.buttons.count).eql(5);
+});
+
+test('Entering a new search term resets current page', async (t) => {
+  const pager = Page.pagers[0];
+  await t
+    // First search for 'moo'
+    .typeText(Page.searchInput, 'moo', { paste: true })
+    .click(Page.searchSubmit)
+    .expect(Page.results.count).eql(10)
+    .expect(pager.buttons.withText('2').exists).ok()
+    .click(pager.buttons.withText('2'))
+    .expect(Page.results.count).eql(2)
+    // Second search for 'animal'
+    .typeText(Page.searchInput, 'animal', { paste: true, replace: true })
+    .click(Page.searchSubmit)
+    .expect(Page.results.count).eql(8)
+    .expect(pager.pager.withText('8 of 8 items').exists).ok();
+});
+
+test('Selecting or deselecting a facet resets current page', async (t) => {
+  const pager = Page.pagers[0];
+
+  const facet = {
+    category: 'Resource Type',
+    value: 'Dataset'
+  };
+
+  await pager.goToPage(3);
+
+  await Page.selectFacet(facet.category, facet.value);
+
+  // Checking the current results list should be sufficient, because if the page
+  // param were set to anything other than the first page, then no results
+  // would be shown
+  await t
+    .expect(pager.pager.withText('10 of 10 items').exists).ok()
+    .expect(Page.results.count).eql(10);
+});


### PR DESCRIPTION
Fixes https://github.com/jhu-idc/iDC-general/issues/414

Reset current page to the first page
* Basic search term is changed
* A facet is selected / deselected
* An advanced search filter is updated (collection filter, date filter, language filter)
* The advanced search terms query is updated

Basic list options (sort order, sort by, and items per page) are not modified when this happens

If testing manually, I'd recommend running `make reset` then bringing in the assets through migrations in the end-to-end tests. Then in various search forms, if you navigate to a page (that isn't the first page) then change any of the aspects above, when the search results are updated, you should be sitting at the first page. Previously, you'd sometimes be presented with no results, even though the query was correct, because it was trying to read, for example, page 3 of the results, when there was only 1 page of results available. 