### PR TITLE
Small change to element sort order in global search

### DIFF
--- a/codebase/config/sync/google_tag.container.idc_gtm_info.yml
+++ b/codebase/config/sync/google_tag.container.idc_gtm_info.yml
@@ -8,7 +8,7 @@ dependencies:
 id: idc_gtm_info
 label: 'IDC GTM Info'
 weight: 0
-container_id:
+container_id: null
 data_layer: dataLayer
 include_classes: false
 whitelist_classes: |-
@@ -46,19 +46,11 @@ conditions:
     id: context_all
     values: ''
     negate: null
-  http_status_code:
-    id: http_status_code
-    status_codes: {  }
-    negate: false
   node_is_published:
     id: node_is_published
     negate: 0
     context_mapping:
       node: '@node.node_route_context:node'
-  request_domain:
-    id: request_domain
-    domains: ''
-    negate: false
   user_status:
     id: user_status
     user_status:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_audio.yml
@@ -20,8 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_document.yml
@@ -20,8 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_extracted_text.yml
@@ -21,8 +21,8 @@ source:
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
     FORMAT: basic_html
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_file.yml
@@ -20,8 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_image.yml
@@ -20,8 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:

--- a/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
+++ b/codebase/config/sync/migrate_plus.migration.idc_ingest_media_video.yml
@@ -20,8 +20,8 @@ source:
     ADMIN: 1
     DRUPAL_FS: 'private://'
     TMP_FS: /tmp/
-    DATE_FORMAT: 'Y-m-d'
-    DIR_DELIMITER: '/'
+    DATE_FORMAT: Y-m-d
+    DIR_DELIMITER: /
 process:
   field_unique_id: unique_id
   _url_filename:
@@ -62,7 +62,6 @@ process:
       - constants/DRUPAL_FS
       - '@_destination_dir'
       - '@_url_filename'
-
   field_access_terms:
     -
       plugin: skip_on_empty

--- a/codebase/config/sync/views.view.solr_search_content.yml
+++ b/codebase/config/sync/views.view.solr_search_content.yml
@@ -224,7 +224,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
+          order: ASC
           exposed: false
           expose:
             label: 'Content type'

--- a/end-to-end/tests/ui/collections.spec.js
+++ b/end-to-end/tests/ui/collections.spec.js
@@ -67,18 +67,18 @@ test('Proximity search syntax', async (t) => {
  * the ordering has changed.
  */
 test('List option: sort order', async (t) => {
-  const orderValue = 'sort_order=ASC';
+  const orderValue = 'sort_order=DESC';
   await doSearch(t, 'animal');
 
   await t
     .expect(page.results.count).eql(7)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).ok();
+    .expect(page.results.nth(0).withText('Duck Collection').exists).ok();
 
   await page.listOptions.sortOrder.setValue(`&${orderValue}`);
 
   await t
     .expect(await getCurrentUrl()).contains(orderValue)
-    .expect(page.results.nth(0).withText('Arctic Animals').exists).notOk();
+    .expect(page.results.nth(0).withText('Arctic Animals').exists).ok();
 });
 
 test('List option: sort by', async (t) => {

--- a/end-to-end/tests/ui/collections.spec.js
+++ b/end-to-end/tests/ui/collections.spec.js
@@ -87,7 +87,7 @@ test('List option: sort by', async (t) => {
 
   await t
     .expect(page.results.count).eql(4)
-    .expect(page.results.nth(0).withText('Moo').exists).ok();
+    .expect(page.results.nth(0).withText('Duck Collection').exists).ok();
 
   await page.listOptions.sortBy.setValue(`&${value}`);
 


### PR DESCRIPTION
I missed this before when checking @jabrah's recent search [PR](https://github.com/jhu-idc/iDC-general/issues/233).  

Collections will now be shown before repository items, which meets our requirements for this ([IDC-7](https://docs.google.com/document/d/15cbz2dqNrSHXsHBvST6Cq8G86SOFSypT/edit)): `Collections will be returned in the results with a higher relevance rating than an item in the collection itself.` I'm sorry I didn't catch this sooner.  As @jabrah is out, I figured I'd just create a PR for this after checking in with @jaredgalanis. 

Changes are located in the `codebase/config/sync/views.view.solr_search_content.yml` file and a few tests for it.  Other changes in yml files are from drupal re-writing yml files and are fairly insignificant. 

It would be good to have whomever reviews this to check that I'm reading the requirements correctly.  Thanks!

To test: 
  - [ ] check that I read requirements correctly :-)
  - [ ] spin up the system based on the branch and try out a search. Ensure that collections show up first in the list and that itmes show up after them. Try out the Global Search, Collection List Search and the Advanced search 