### PR TITLE
Bump JWT expiry to one week

### DIFF
--- a/codebase/config/sync/islandora.settings.yml
+++ b/codebase/config/sync/islandora.settings.yml
@@ -1,5 +1,5 @@
 broker_url: 'tcp://activemq:61613'
-jwt_expiry: '+2 hour'
+jwt_expiry: '+168 hour'
 gemini_url: 'http://gemini:8000'
 gemini_pseudo_bundles:
   - 'islandora_object:node'


### PR DESCRIPTION
This virtually assures that JWT tokens won't expire before events are processed from a slow queue.  Based on Danny's recommendation for very long JWT expiry times to avoid cascading failure.

Resolves #246 