### PR TITLE
UI tweaks

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8064,12 +8064,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "5cf8923e9a785de7aac4b79a76a4afac978f5229"
+                "reference": "55f7dd41eecfa54c1918e68a34ea9f5ffb95e718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/5cf8923e9a785de7aac4b79a76a4afac978f5229",
-                "reference": "5cf8923e9a785de7aac4b79a76a4afac978f5229",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/55f7dd41eecfa54c1918e68a34ea9f5ffb95e718",
+                "reference": "55f7dd41eecfa54c1918e68a34ea9f5ffb95e718",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8079,7 +8079,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/main",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-09-24T20:55:05+00:00"
+            "time": "2021-10-06T15:01:55+00:00"
         },
         {
             "name": "jhu-idc/idc_defaults",
@@ -8149,12 +8149,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "e9590662445e04db1f35c34bf5e2ad37c2bcd8e9"
+                "reference": "bced35fb02d74a6c59aec9093773407bc45b6d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/e9590662445e04db1f35c34bf5e2ad37c2bcd8e9",
-                "reference": "e9590662445e04db1f35c34bf5e2ad37c2bcd8e9",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/bced35fb02d74a6c59aec9093773407bc45b6d02",
+                "reference": "bced35fb02d74a6c59aec9093773407bc45b6d02",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8164,7 +8164,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2021-09-24T18:23:44+00:00"
+            "time": "2021-10-06T16:05:03+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",

--- a/end-to-end/tests/ui/advanced-search.spec.js
+++ b/end-to-end/tests/ui/advanced-search.spec.js
@@ -91,6 +91,7 @@ test('Collection filter', async (t) => {
     .expect(pager.pager.withText('24 of 24 items').exists).ok();
 
   await t
+    .click(Page.collectionsFilter.toggle) // Closed by default, need to open it first
     .typeText(Page.collectionsFilter.input, 'collection', { paste: true})
     .expect(Page.collectionsFilter.suggestions.count).eql(10)
     .typeText(Page.collectionsFilter.input, 'duck', { replace: true, paste: true })

--- a/end-to-end/tests/ui/collection-details.spec.js
+++ b/end-to-end/tests/ui/collection-details.spec.js
@@ -64,14 +64,15 @@ test('Facet toggle', async (t) => {
   const category = 'Year';
   const valueContainer = Page.facetValueContainer(category);
   await t
-    .expect(valueContainer.clientHeight).gt(0)
+    .expect(valueContainer.clientHeight).eql(0)
     .click(Page.facetToggle(category))
-    .expect(valueContainer.clientHeight).eql(0);
+    .expect(valueContainer.clientHeight).gt(0);
 });
 
 test('Selecting facets', async (t) => {
   const category = 'Year';
   await t
+    .click(Page.facetToggle(category))
     .expect(Page.facetValues(category).count).eql(2)
     .expect(Page.results.count).eql(3);
 

--- a/end-to-end/tests/ui/pages/advanced-search.js
+++ b/end-to-end/tests/ui/pages/advanced-search.js
@@ -42,6 +42,7 @@ class QueryTerm {
 class CollectionsFilter {
   constructor() {
     const container = new Selector('[data-test-collection-lookup-filter]');
+    this.toggle = container.parent().sibling('button');
     this.selectedCollections = container.find('[data-test-collection-lookup-selected-item]');
     this.input = container.find('[data-test-collection-lookup-input]');
     this.clearBtn = this.input.parent().find('button[title="Clear"]');
@@ -57,10 +58,12 @@ export class AdvancedSearch extends Searchable {
     this.collectionsFilter = new CollectionsFilter();
 
     this.languageFilter = new Selector('[data-test-language-filter]');
+    this.languageToggle = this.languageFilter.parent().sibling('button');
     this.langaugeFilterOptions = this.languageFilter.find('[data-test-language-filter-item]');
     this.selectedLanguages = this.languageFilter.find('[data-test-language-filter-item].bg-blue-spirit');
 
     this.dateFilter = new Selector('[data-test-date-filter]');
+    this.dateToggle = this.dateFilter.parent().sibling('button');
     this.dateInput1 = this.dateFilter.find('input').nth(0);
     this.dateInput2 = this.dateFilter.find('input').nth(1);
 

--- a/end-to-end/tests/ui/search-page.spec.js
+++ b/end-to-end/tests/ui/search-page.spec.js
@@ -38,6 +38,8 @@ test('Selecting or deselecting a facet resets current page', async (t) => {
 
   await pager.goToPage(3);
 
+  await t.click(Page.facetToggle(facet.category));
+
   await Page.selectFacet(facet.category, facet.value);
 
   // Checking the current results list should be sufficient, because if the page


### PR DESCRIPTION
## Update theme/module to bring in ui tweaks. 

* Facets and advanced search filters are closed by default - except for the date filter
* Added title to advanced search page
* Placeholder text updated for the search input in the collections list page
* Show 3 empty search terms in the advanced search page by default
  * The Clear button will clear search terms and restore 3 terms
  * Validation updated to ignore empty terms, where before all terms were required to search
* Advanced search inputs sizes normalized to better match other inputs in the app
* Proximity search in advanced search: the "Range" input changed to accept only numbers, should no longer show "NaN" if a user enters non-number characters
* Restrict height of facet panels
* Update tests to accommodate

![image](https://user-images.githubusercontent.com/5167587/136101199-1bb4d168-b2b9-466f-b04b-5354cccd2f64.png)