### PR TITLE
Bumps the docker images pulled in to grab houdini fix

### DIFF
--- a/.env
+++ b/.env
@@ -70,7 +70,8 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-57-g602edfa
+#TAG=upstream-20200824-f8d1e8e-57-g602edfa
+TAG=upstream-20200824-f8d1e8e-59-g008cfb7
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319

--- a/.env
+++ b/.env
@@ -70,8 +70,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-#TAG=upstream-20200824-f8d1e8e-57-g602edfa
-TAG=upstream-20200824-f8d1e8e-59-g008cfb7
+TAG=upstream-20200824-f8d1e8e-60-g891acc8
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319

--- a/tests/12-media-tests/testcafe/migrate_derivative.spec.js
+++ b/tests/12-media-tests/testcafe/migrate_derivative.spec.js
@@ -357,14 +357,17 @@ test('Migrate PDF for Derivative Generation', async t => {
     // no service files are generated for PDFs
     const thumb_derivative = Selector('div.view-content').find('a').withText('Thumbnail Image.png');
     const fits_derivative = Selector('div.view-content').find('a').withText('FITS File.xml');
+    const ocr_derivative = Selector('div.view-content').find('a').withText('Extracted Text.txt');
 
     console.log("Checking for derivatives ...")
 
     await t.expect(await tryUntilTrue(async () => {
         const thumb_count = await thumb_derivative.count
         const fits_count = await fits_derivative.count
-        console.log("thumb count: ", thumb_count, ", fits count:", fits_count);
-        if (thumb_count < 1 || fits_count < 1) {
+        const ocr_count = await ocr_derivative.count
+        console.log('thumb count: ', thumb_count, ', fits count: ', fits_count,
+          ', extracted text count: ', ocr_count);
+        if (thumb_count < 1 || fits_count < 1 || ocr_count < 1) {
             await t.eval(() => location.reload(true));
             return false;
         }
@@ -373,6 +376,7 @@ test('Migrate PDF for Derivative Generation', async t => {
 
     await t.expect(thumb_derivative.count).eql(1);
     await t.expect(fits_derivative.count).eql(1);
+    await t.expect(ocr_derivative.count).eql(1);
 });
 
 

--- a/tests/12-media-tests/testcafe/migrate_derivative.spec.js
+++ b/tests/12-media-tests/testcafe/migrate_derivative.spec.js
@@ -100,7 +100,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await doMigration(t, migrationType.NEW_MEDIA_VIDEO, './migrations/derivative-video.csv');
     await doMigration(t, migrationType.NEW_MEDIA_AUDIO, './migrations/derivative-audio.csv');
 
-    // This is a 4 part test: 
+    // This is a 4 part test:
     // 1) there should be one video with a deriv
     // 2) there should be one video w/o a deriv
     // 3) there should be one audio file with a deriv
@@ -115,7 +115,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await t.expect(io.count).eql(1);
 
     // list its media
-    try { 
+    try {
         await t.click(io)
         await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'))
     } catch (err){
@@ -171,7 +171,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await t.expect(io.count).eql(1);
 
     // list its media
-    try { 
+    try {
         await t.click(io)
         await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'))
     } catch (err){
@@ -213,7 +213,7 @@ test('Test Video Derivative Generation Conditions', async t => {
         return true;
     })).eql(true, "Derivatives have not appeared");
 
-    // there should be no service file. It could show up later, so this might be a weak test. 
+    // there should be no service file. It could show up later, so this might be a weak test.
     await t.expect(service_derivative.count).eql(0);
     await t.expect(thumb_derivative.count).eql(1);
     await t.expect(fits_derivative.count).eql(1);
@@ -227,7 +227,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await t.expect(io.count).eql(1);
 
     // list its media
-    try { 
+    try {
         await t.click(io)
         await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'))
     } catch (err){
@@ -279,7 +279,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await t.expect(io.count).eql(1);
 
     // list its media
-    try { 
+    try {
         await t.click(io)
         await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'))
     } catch (err){
@@ -301,7 +301,7 @@ test('Test Video Derivative Generation Conditions', async t => {
     await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Original File')
     await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Service File');
 
-    // check for the presence of a Service and FITs file. Though there should not be 
+    // check for the presence of a Service and FITs file. Though there should not be
     // a separate Service File
     service_derivative = Selector('div.view-content').find('a').withText('Service File.mp3');
     fits_derivative = Selector('div.view-content').find('a').withText('FITS File.xml');
@@ -319,7 +319,60 @@ test('Test Video Derivative Generation Conditions', async t => {
         return true;
     })).eql(true, "Derivatives have not appeared");
 
-    // there should be no service file. It could show up later, so this might be a weak test. 
+    // there should be no service file. It could show up later, so this might be a weak test.
     await t.expect(service_derivative.count).eql(0);
     await t.expect(fits_derivative.count).eql(1);
 });
+
+test('Migrate PDF for Derivative Generation', async t => {
+
+    // migrate the test objects into Drupal
+    await doMigration(t, migrationType.NEW_COLLECTION, './migrations/derivative-collection.csv');
+    await doMigration(t, migrationType.NEW_ITEM, './migrations/derivative-islandora_object.csv');
+    await doMigration(t, migrationType.NEW_MEDIA_DOCUMENT, './migrations/derivative-document.csv');
+
+    // verify the presence of the islandora object
+    const io_name = "Derivative Repository Item PDF"
+    await t.navigateTo(contentList)
+    const io = Selector('div.view-content').find('a').withText(io_name)
+    await t.expect(io.count).eql(1);
+
+    // list its media
+
+    await t.click(io)
+    await t.click(Selector('#block-idcui-local-tasks').find('a').withText('Media'))
+
+    // assert the presence of the original media
+    const media_name = 'ilford_temprature-compensation-chart.pdf';
+    const media = Selector('div.view-content').find('a').withText(media_name);
+    await t.expect(media.count).eql(1);
+
+    // assert expected attributes of the original media
+    await t.expect(media.parent('tr').child('td').nth(2).innerText).eql('Document')
+    await t.expect(media.parent('tr').child('td').nth(3).innerText).eql('application/pdf')
+    await t.expect(media.parent('tr').child('td').nth(4).innerText).contains('Original File')
+
+    // assert the presence of a derivative thumbnail and fits file
+    // (increase timeout in case derivatives haven't been created yet?)
+    // no service files are generated for PDFs
+    const thumb_derivative = Selector('div.view-content').find('a').withText('Thumbnail Image.png');
+    const fits_derivative = Selector('div.view-content').find('a').withText('FITS File.xml');
+
+    console.log("Checking for derivatives ...")
+
+    await t.expect(await tryUntilTrue(async () => {
+        const thumb_count = await thumb_derivative.count
+        const fits_count = await fits_derivative.count
+        console.log("thumb count: ", thumb_count, ", fits count:", fits_count);
+        if (thumb_count < 1 || fits_count < 1) {
+            await t.eval(() => location.reload(true));
+            return false;
+        }
+        return true;
+    })).eql(true, "Derivatives have not appeared");
+
+    await t.expect(thumb_derivative.count).eql(1);
+    await t.expect(fits_derivative.count).eql(1);
+});
+
+

--- a/tests/12-media-tests/testcafe/migrations/derivative-collection.csv
+++ b/tests/12-media-tests/testcafe/migrations/derivative-collection.csv
@@ -1,2 +1,2 @@
-unique_id,node_id,title,title_language,alternative_title,member_of,contact_email,contact_name,collection_number,description,finding_aid
-derivative-collection-01,,Derivative Collection,::name:English,,,,,,Collection for Derivative tests;;eng,
+unique_id,node_id,title,title_language,alternative_title,member_of,contact_email,contact_name,collection_number,description,finding_aid,access_terms
+derivative-collection-01,,Derivative Collection,::name:English,,,,,,Collection for Derivative tests;;eng,,:::media_accesscontrol_01

--- a/tests/12-media-tests/testcafe/migrations/derivative-document.csv
+++ b/tests/12-media-tests/testcafe/migrations/derivative-document.csv
@@ -1,0 +1,2 @@
+unique_id,name,original_name,mime_type,media_of,media_use,url
+mf_doc_00001,ilford_temprature-compensation-chart.pdf,ilford_temperature-compensation-chart.pdf,application/pdf,:::derivative_io_06,Original File,http://migration-assets/assets/document/ilford_temperature-compensation-chart.pdf

--- a/tests/12-media-tests/testcafe/migrations/derivative-islandora_object.csv
+++ b/tests/12-media-tests/testcafe/migrations/derivative-islandora_object.csv
@@ -4,3 +4,4 @@ derivative_io_02,,Derivative Repository Item Video With Deriv,::title:Derivative
 derivative_io_03,,Derivative Repository Item Video With No Deriv,::title:Derivative Collection,Video
 derivative_io_04,,Derivative Repository Item Audio With Deriv,::title:Derivative Collection,Audio
 derivative_io_05,,Derivative Repository Item Audio With No Deriv,::title:Derivative Collection,Audio
+derivative_io_06,,Derivative Repository Item PDF,::title:Derivative Collection,Digital Document

--- a/tests/12-media-tests/testcafe/util.js
+++ b/tests/12-media-tests/testcafe/util.js
@@ -156,9 +156,10 @@ export const doMigration = async (t, migrationType, file) => {
 export const migrationType = {
   NEW_ITEM: "idc_ingest_new_items",
   NEW_COLLECTION: "idc_ingest_new_collection",
+  NEW_MEDIA_AUDIO: "idc_ingest_media_audio",
+  NEW_MEDIA_DOCUMENT: "idc_ingest_media_document",
   NEW_MEDIA_FILE: "idc_ingest_media_file",
   NEW_MEDIA_IMAGE: "idc_ingest_media_image",
-  NEW_MEDIA_AUDIO: "idc_ingest_media_audio",
   NEW_MEDIA_VIDEO: "idc_ingest_media_video",
   NEW_ACCESS_TERMS: "idc_ingest_taxonomy_islandora_accessterms"
 };

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-thumb.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-thumb.json
@@ -1,0 +1,9 @@
+{
+  "type": "media",
+  "bundle": "document",
+  "name": "41-Thumbnail Image.jpg",
+  "use": [
+    "Thumbnail Image"
+  ],
+  "media_of": "Derivative Documents"
+}

--- a/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-thumb.json
+++ b/tests/21-large-file-derivatives-nightly/verification/expected/media-documents-thumb.json
@@ -1,7 +1,7 @@
 {
   "type": "media",
-  "bundle": "document",
-  "name": "41-Thumbnail Image.jpg",
+  "bundle": "image",
+  "name": "41-Thumbnail Image.png",
   "use": [
     "Thumbnail Image"
   ],

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -35,7 +35,7 @@ const (
 	expectedOriginalVideoCount          = 2
 	expectedOriginalImageCount          = 5
 	expectedDerivativeThumbCount        = expectedRepoObjectCount
-	expectedDerivativeFitsCount         = expectedRepoObjectCount
+	expectedDerivativeFitsCount         = expectedRepoObjectCount - 1                                   // TODO: the first image doesn't have a FITS file
 	expectedDerivativeExtractedTxtCount = expectedOriginalDocumentsMediaCount                           // Only the PDF has extracted text
 	expectedDerivativeServiceCount      = expectedRepoObjectCount - expectedOriginalDocumentsMediaCount // The PDF doesn't have a service file; TODO: Missing service files for the large and small video
 )
@@ -66,7 +66,7 @@ var expectedCount = struct {
 	expectedOriginalVideoCount,
 	expectedOriginalImageCount,
 	expectedDerivativeThumbCount,
-	expectedDerivativeFitsCount - 1,   // TODO: the first image doesn't have a FITS file
+	expectedDerivativeFitsCount,
 	expectedDerivativeExtractedTxtCount,
 	expectedDerivativeServiceCount,
 }

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -285,6 +285,7 @@ func Test_Derivative_Thumbnail_Media(t *testing.T) {
 func Test_Derivative_Fits_Media(t *testing.T) {
 	// Run derivative tests in parallel to avoid long wait times
 	t.Parallel()
+
 	// Collect the filenames of the expected fits media
 	// TODO: media-image-fits-01 won't have one
 	filenames := filenamesMatching(t, "fits")
@@ -322,6 +323,7 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 					err = errors.New(fmt.Sprintf("too many results retrieving JSONAPI entity %s, bundle %s, %s %s",
 						expectedMedia.EntityType(), expectedMedia.EntityBundle(), expectedMedia.Field(), expectedMedia.NameOrTitle()))
 				}
+
 				return err
 			}, time.Now().Add(defaultTimeout*time.Millisecond), 1000, 2.0)
 
@@ -330,6 +332,7 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 			wg.Done()
 		}()
 	}
+
 	wg.Wait()
 }
 

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -285,7 +285,7 @@ func Test_Derivative_Thumbnail_Media(t *testing.T) {
 func Test_Derivative_Fits_Media(t *testing.T) {
 	// Run derivative tests in parallel to avoid long wait times
 	t.Parallel()
-
+	log.Printf("Running Test_Derivative_Fits_Media")
 	// Collect the filenames of the expected fits media
 	// TODO: media-image-fits-01 won't have one
 	filenames := filenamesMatching(t, "fits")
@@ -296,10 +296,12 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(filenames))
+	log.Printf("initialized wait groups. Added %d", len(filenames))
 	for _, filename := range filenames {
 		expectedMedia := &model.ExpectedMediaGeneric{}
 		unmarshalErr := unmarshal(filename, expectedMedia)
 		assert.Nil(t, unmarshalErr, "error unmarshaling '%s': %s", filename, unmarshalErr)
+		log.Printf("now looking at filename: %s", filename)
 
 		var filteredMedia filterable
 		filteredMedia = applyDerivedMediaFilter(expectedMedia, expectedMedia.MediaOf)
@@ -320,19 +322,21 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 				})
 
 				if len(actual.JsonApiData) > 1 {
+					log.Printf("too many results!")
 					err = errors.New(fmt.Sprintf("too many results retrieving JSONAPI entity %s, bundle %s, %s %s",
 						expectedMedia.EntityType(), expectedMedia.EntityBundle(), expectedMedia.Field(), expectedMedia.NameOrTitle()))
 				}
-
+				log.Printf("Return an error")
 				return err
 			}, time.Now().Add(defaultTimeout*time.Millisecond), 1000, 2.0)
 
 			assert.Equal(t, done, err, "Failed retrieving '%s': %s", expectedMedia.NameOrTitle(), err)
 
+			log.Printf("one is done; things are good")
 			wg.Done()
 		}()
 	}
-
+	log.Printf("Hitting the final Wait")
 	wg.Wait()
 }
 

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -34,8 +34,8 @@ const (
 	expectedOriginalDocumentsMediaCount = 1
 	expectedOriginalVideoCount          = 2
 	expectedOriginalImageCount          = 5
-	expectedDerivativeThumbCount        = expectedRepoObjectCount - expectedOriginalDocumentsMediaCount // the PDF doesn't have a thumbnail
-	expectedDerivativeFitsCount         = expectedRepoObjectCount - 1                                   // TODO: the first image doesn't have a FITS file
+	expectedDerivativeThumbCount        = expectedRepoObjectCount
+	expectedDerivativeFitsCount         = expectedRepoObjectCount
 	expectedDerivativeExtractedTxtCount = expectedOriginalDocumentsMediaCount                           // Only the PDF has extracted text
 	expectedDerivativeServiceCount      = expectedRepoObjectCount - expectedOriginalDocumentsMediaCount // The PDF doesn't have a service file; TODO: Missing service files for the large and small video
 )
@@ -231,7 +231,6 @@ func Test_Derivative_Thumbnail_Media(t *testing.T) {
 	t.Parallel()
 
 	// Collect the filenames of the expected thumbnail media
-	// - the PDF (media-documents-original) won't have one
 	filenames := filenamesMatching(t, "thumb")
 	assert.Len(t, filenames, expectedCount.derivativeThumbnails,
 		"Expected %d files but got %d", expectedCount.derivativeThumbnails, len(filenames))

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -66,7 +66,7 @@ var expectedCount = struct {
 	expectedOriginalVideoCount,
 	expectedOriginalImageCount,
 	expectedDerivativeThumbCount,
-	expectedDerivativeFitsCount,
+	expectedDerivativeFitsCount - 1,   // TODO: the first image doesn't have a FITS file
 	expectedDerivativeExtractedTxtCount,
 	expectedDerivativeServiceCount,
 }

--- a/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
+++ b/tests/21-large-file-derivatives-nightly/verification/verify_migrations_test.go
@@ -285,7 +285,6 @@ func Test_Derivative_Thumbnail_Media(t *testing.T) {
 func Test_Derivative_Fits_Media(t *testing.T) {
 	// Run derivative tests in parallel to avoid long wait times
 	t.Parallel()
-	log.Printf("Running Test_Derivative_Fits_Media")
 	// Collect the filenames of the expected fits media
 	// TODO: media-image-fits-01 won't have one
 	filenames := filenamesMatching(t, "fits")
@@ -296,12 +295,10 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(len(filenames))
-	log.Printf("initialized wait groups. Added %d", len(filenames))
 	for _, filename := range filenames {
 		expectedMedia := &model.ExpectedMediaGeneric{}
 		unmarshalErr := unmarshal(filename, expectedMedia)
 		assert.Nil(t, unmarshalErr, "error unmarshaling '%s': %s", filename, unmarshalErr)
-		log.Printf("now looking at filename: %s", filename)
 
 		var filteredMedia filterable
 		filteredMedia = applyDerivedMediaFilter(expectedMedia, expectedMedia.MediaOf)
@@ -322,21 +319,17 @@ func Test_Derivative_Fits_Media(t *testing.T) {
 				})
 
 				if len(actual.JsonApiData) > 1 {
-					log.Printf("too many results!")
 					err = errors.New(fmt.Sprintf("too many results retrieving JSONAPI entity %s, bundle %s, %s %s",
 						expectedMedia.EntityType(), expectedMedia.EntityBundle(), expectedMedia.Field(), expectedMedia.NameOrTitle()))
 				}
-				log.Printf("Return an error")
 				return err
 			}, time.Now().Add(defaultTimeout*time.Millisecond), 1000, 2.0)
 
 			assert.Equal(t, done, err, "Failed retrieving '%s': %s", expectedMedia.NameOrTitle(), err)
 
-			log.Printf("one is done; things are good")
 			wg.Done()
 		}()
 	}
-	log.Printf("Hitting the final Wait")
 	wg.Wait()
 }
 


### PR DESCRIPTION
Resolves: https://github.com/jhu-idc/idc-isle-dc/issues/190

This pulls in the latest containers to grab a fix for generating thumbnails from PDF Media files. 

This also creates a test to upload a PDF file and test derivative generation for it.  Also tweaks tests in the large file tests to change what the expected derivatives for PDF files are. 