### PR TITLE
Fix a test in the end_to_end tests by increasing a timeout

### DIFF
--- a/end-to-end/tests/ui/advanced-search.spec.js
+++ b/end-to-end/tests/ui/advanced-search.spec.js
@@ -68,7 +68,7 @@ test('Normal search', async (t) => {
     .click(term1.nonproxyTerm.field)
     .click(term1.nonproxyTerm.fields.withText('Title'))
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(2);
+    .expect(Page.results.count).eql(2, { timeout: 30000 });
 
   await t.click(Page.addTermBtn);
 


### PR DESCRIPTION
We've seen a timeout in a few PR's during a certain test. For the most part this test runs fine, but sometimes it doesn't appear to have enough time to render search results before the test checks the values and then reports and error. 

Hopefully this timeout will make it so the test functions more consistently. 

"Fix" might be too strong a word - this may or may not fix things.  