### PR TITLE
Update the nightly job to always capture container logs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
                 chmod a+rwx end-to-end/reports
                 make test test=${{ matrix.suite }}
             - name: reports
-              if: failure()
+              if: always()
               run: |
                 mkdir -p end-to-end/reports/${{ matrix.suite }}
                 docker ps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,13 @@ jobs:
                 docker logs idc_fits_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/fits-${{ matrix.suite }}.log
                 docker logs idc_houdini_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/houdini-${{ matrix.suite }}.log
             - name: upload reports
-              if: failure()
+              if: always()
               uses: actions/upload-artifact@v2
               with:
                 name: reports-${{ matrix.suite }}
                 path: end-to-end/reports/${{ matrix.suite }}
             - name: upload screenshots
-              if: failure()
+              if: always()
               uses: actions/upload-artifact@v2
               with:
                 name: reports-screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
                 docker logs idc_drupal_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/drupal-${{ matrix.suite }}.log
                 docker logs idc_alpaca_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/alpaca-${{ matrix.suite }}.log
                 docker logs idc_homarus_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/homarus-${{ matrix.suite }}.log
+                docker logs idc_crayfits_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/crayfits-${{ matrix.suite }}.log
+                docker logs idc_fits_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/fits-${{ matrix.suite }}.log
+                docker logs idc_houdini_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/houdini-${{ matrix.suite }}.log
             - name: upload reports
               if: failure()
               uses: actions/upload-artifact@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,13 +76,18 @@ jobs:
           chmod a+rwx end-to-end/reports
           make test test=${{ matrix.suite }}
       - name: reports
+        if: always()
         run: |
           mkdir -p end-to-end/reports/${{ matrix.suite }}
           docker ps
           docker logs idc_drupal_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/drupal-${{ matrix.suite }}.log
           docker logs idc_alpaca_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/alpaca-${{ matrix.suite }}.log
           docker logs idc_homarus_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/homarus-${{ matrix.suite }}.log
+          docker logs idc_crayfits_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/crayfits-${{ matrix.suite }}.log
+          docker logs idc_fits_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/fits-${{ matrix.suite }}.log
+          docker logs idc_houdini_1 2>&1 | tee end-to-end/reports/${{ matrix.suite }}/houdini-${{ matrix.suite }}.log
       - name: upload reports
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: reports-${{ matrix.suite }}


### PR DESCRIPTION
Always run the 'reports' and 'upload reports' job, regardless of test outcome.  Include 'crayfits', 'fits', and 'houdini' container log output.