### PR TITLE
Add trusted hosts configuration for Drupal.

### DIFF
--- a/codebase/web/sites/default/settings.local.php
+++ b/codebase/web/sites/default/settings.local.php
@@ -71,3 +71,8 @@ $config['google_tag.container.idc_gtm_info']['container_id'] = getenv('DRUPAL_GT
 
 # Make the timeout for the default Guzzle client something crazy big to avoid timeouts on large media
 $settings['http_client_config']['timeout'] = 99999999;
+
+$settings['trusted_host_patterns'] = [
+  '^.+\.traefik\.me$',
+  '^.+\.library\.jhu\.edu$',
+ ];


### PR DESCRIPTION
This change places limitations on the value of the HTTP `Host` header used when making requests to Drupal.  Values for the `Host` header _must_ match one of the regular expressions:
* ^.+\.traefik\.me$
* ^.+\.library\.jhu\.edu$

Any other value will be rejected.

Closes https://github.com/jhu-idc/iDC-general/issues/452


## To test

* Start the stack (`make up`) and successfully load the home page `https://islandora-idc.traefik.me/`
* Edit the values for `$settings['trusted_host_patterns']` in `settings.local.php`, and change `^.+\.traefik\.me$` to `^moo\.traefik\.me$`
* Stop and remove the `idc_drupal_1` container (`docker rm -f idc_drupal_1`)
* Start a new drupal container `docker-compose up -d`
* Attempt to load the home page

You should see a message `The provided host name is not valid for this server.`

## Discussion

Restricting values of the `Host` header must be done with care so that legitimate access to Drupal is not broken.  So this PR allows any value that ends in `.traefik.me` or `.library.jhu.edu`.  That way there's some flexibility in the host names used in development and production environments.

If domain names other than `.traefik.me` or `.library.jhu.edu` are used, the values for `$settings['trusted_host_patterns']` will need to be updated. 

Because the Traefik proxy will reject hosts it is not configured for, it can actually interfere when testing this PR, so just be aware of that.  Traefik will accept any requests to `*.traefik.me`, which is why the test for the PR uses `moo.traefik.me` rather than `localhost` or `foo.bar.com`.  (Traefik is not used in production).

