### PR TITLE
Fix duplicate eppn issue.

### DIFF
--- a/codebase/patches/simplesaml_config.patch
+++ b/codebase/patches/simplesaml_config.patch
@@ -438,7 +438,7 @@ new file mode 100644
 index 00000000..399dde26
 --- /dev/null
 +++ b/config/config.php
-@@ -0,0 +1,1225 @@
+@@ -0,0 +1,1224 @@
 +<?php
 +/*
 + * The configuration of SimpleSAMLphp
@@ -1468,7 +1468,6 @@ index 00000000..399dde26
 +            'urn:oid:1.3.6.1.4.1.5923.1.1.1.1' => 'eduPersonAffiliation',
 +            'urn:oid:1.3.6.1.4.1.5923.1.1.1.13' => 'eduPersonUniqueId',
 +            'urn:oid:1.3.6.1.4.1.5923.1.1.1.6' => 'eduPersonPrincipalName',
-+            'urn:oid:1.2.840.113556.1.4.656' => 'eduPersonPrincipalName',
 +            'urn:oid:1.3.6.1.4.1.5923.1.1.1.9' => 'eduPersonScopedAffiliation',
 +            'urn:oid:2.16.840.1.113730.3.1.3' => 'employeeNumber',
 +            'urn:oid:2.16.840.1.113730.3.1.241' => 'displayName',


### PR DESCRIPTION
Remove a duplicate mapping for eduPersonPrincipalName.

IT@JH sends values for both attributes:
1.2.840.113556.1.4.656: the Microsoft userPrincipalName
1.3.6.1.4.1.5923.1.1.1.6: the InCommon eduPersonPrincipalName

The configuration for SimpleSAML maps both OIDs to `eduPersonPrincipalName`, and picks one of the mappings at random.  Since 1.4.656 and 1.1.1.6 are assigned different values by IT@JH, this manifests as the duplicate user problem.

This PR removes the 1.2.840.113556.1.4.656 OID from the mapping, since we only care about the InCommon eppn.  Having a single mapping for eppn (1.3.6.1.4.1.5923.1.1.1.6) removes the ambiguity, and ought to result in stable values of eppn moving forward.

Closes https://github.com/jhu-idc/iDC-general/issues/457