### PR TITLE
View for JScholarship Redirects

### DIFF
--- a/codebase/config/sync/views.view.jscholarship_redirects.yml
+++ b/codebase/config/sync/views.view.jscholarship_redirects.yml
@@ -1,0 +1,1748 @@
+uuid: 91d4a00b-6c6d-4e3b-8247-70b14f4cab2b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_abstract
+    - field.storage.node.field_access_rights
+    - field.storage.node.field_alternative_title
+    - field.storage.node.field_citable_url
+    - field.storage.node.field_collection_contact_name
+    - field.storage.node.field_collection_number
+    - field.storage.node.field_contributor
+    - field.storage.node.field_copyright_and_use
+    - field.storage.node.field_copyright_holder
+    - field.storage.node.field_creator
+    - field.storage.node.field_date_available
+    - field.storage.node.field_date_copyrighted
+    - field.storage.node.field_date_created
+    - field.storage.node.field_date_published
+    - field.storage.node.field_description
+    - field.storage.node.field_digital_publisher
+    - field.storage.node.field_dspace_identifier
+    - field.storage.node.field_extent
+    - field.storage.node.field_featured_item
+    - field.storage.node.field_finding_aid
+    - field.storage.node.field_genre
+    - field.storage.node.field_geoportal_link
+    - field.storage.node.field_is_part_of
+    - field.storage.node.field_issn
+    - field.storage.node.field_item_barcode
+    - field.storage.node.field_language
+    - field.storage.node.field_library_catalog_link
+    - field.storage.node.field_member_of
+    - field.storage.node.field_model
+    - field.storage.node.field_oclc_number
+    - field.storage.node.field_publisher
+    - field.storage.node.field_publisher_country
+    - field.storage.node.field_resource_type
+    - field.storage.node.field_spatial_coverage
+    - field.storage.node.field_subject
+    - field.storage.node.field_table_of_contents
+    - field.storage.node.field_title_language
+    - field.storage.node.field_years
+    - search_api.index.default_solr_index
+  module:
+    - controlled_access_terms
+    - csv_serialization
+    - link
+    - reference_value_pair
+    - rest
+    - search_api
+    - serialization
+    - views_data_export
+_core:
+  default_config_hash: 2NtHk5q6F6Uf40yvQROy8auf4vYMVBZ4TVhcj3z6FKI
+id: jscholarship_redirects
+label: 'JScholarship Redirects'
+module: views
+description: 'A search page preconfigured to search through the content of your site'
+tag: ''
+base_table: search_api_index_default_solr_index
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'JScholarship Redirects'
+      fields:
+        title:
+          id: title
+          table: search_api_datasource_default_solr_index_entity_node
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_description:
+          id: field_description
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: reference_value_formatter
+          settings:
+            display_invalid_reference: 1
+            invalid_reference_label: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_date_available:
+          id: field_date_available
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_date_available
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_member_of:
+          id: field_member_of
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              article:
+                display_method: label
+                view_mode: default
+              collection_object:
+                display_method: label
+                view_mode: default
+              islandora_object:
+                display_method: label
+                view_mode: default
+              page:
+                display_method: label
+                view_mode: default
+        search_api_excerpt:
+          id: search_api_excerpt
+          table: search_api_index_default_solr_index
+          field: search_api_excerpt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+        field_alternative_title:
+          id: field_alternative_title
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_alternative_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: reference_value_formatter
+          settings:
+            display_invalid_reference: 1
+            invalid_reference_label: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        nid:
+          id: nid
+          table: search_api_datasource_default_solr_index_entity_node
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_numeric
+          fallback_options:
+            set_precision: false
+            precision: 0
+            decimal: .
+            separator: ','
+            format_plural: false
+            format_plural_string: !!binary MQNAY291bnQ=
+            prefix: ''
+            suffix: ''
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            format_plural_values:
+              - '1'
+              - '@count'
+        search_api_id:
+          id: search_api_id
+          table: search_api_index_default_solr_index
+          field: search_api_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        uuid:
+          id: uuid
+          table: search_api_datasource_default_solr_index_entity_node
+          field: uuid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_abstract:
+          id: field_abstract
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_abstract
+          entity_type: node
+          plugin_id: search_api_field
+        field_abstract_1:
+          id: field_abstract_1
+          table: search_api_index_default_solr_index
+          field: field_abstract
+          plugin_id: search_api_field
+        field_access_rights:
+          id: field_access_rights
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_access_rights
+          entity_type: node
+          plugin_id: search_api_field
+        field_alternative_title_1:
+          id: field_alternative_title_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_alternative_title
+          entity_type: node
+          plugin_id: search_api_field
+        uid:
+          id: uid
+          table: search_api_datasource_default_solr_index_entity_node
+          field: uid
+          entity_type: node
+          plugin_id: search_api_field
+        created:
+          id: created
+          table: search_api_datasource_default_solr_index_entity_node
+          field: created
+          entity_type: node
+          plugin_id: search_api_field
+        field_citable_url:
+          id: field_citable_url
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_citable_url
+          entity_type: node
+          plugin_id: search_api_field
+        field_collection_contact_name:
+          id: field_collection_contact_name
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_collection_contact_name
+          entity_type: node
+          plugin_id: search_api_field
+        field_collection_number:
+          id: field_collection_number
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_collection_number
+          entity_type: node
+          plugin_id: search_api_field
+        type:
+          id: type
+          table: search_api_datasource_default_solr_index_entity_node
+          field: type
+          entity_type: node
+          plugin_id: search_api_field
+        field_contributor:
+          id: field_contributor
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_contributor
+          entity_type: node
+          plugin_id: search_api_field
+        field_copyright_and_use:
+          id: field_copyright_and_use
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_copyright_and_use
+          entity_type: node
+          plugin_id: search_api_field
+        field_copyright_holder:
+          id: field_copyright_holder
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_copyright_holder
+          entity_type: node
+          plugin_id: search_api_field
+        field_creator:
+          id: field_creator
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_creator
+          entity_type: node
+          plugin_id: search_api_field
+        field_date_available_1:
+          id: field_date_available_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_date_available
+          entity_type: node
+          plugin_id: search_api_field
+        field_date_copyrighted:
+          id: field_date_copyrighted
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_date_copyrighted
+          entity_type: node
+          plugin_id: search_api_field
+        field_date_created:
+          id: field_date_created
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_date_created
+          entity_type: node
+          plugin_id: search_api_field
+        field_date_published:
+          id: field_date_published
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_date_published
+          entity_type: node
+          plugin_id: search_api_field
+        field_description_1:
+          id: field_description_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_description
+          entity_type: node
+          plugin_id: search_api_field
+        field_digital_publisher:
+          id: field_digital_publisher
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_digital_publisher
+          entity_type: node
+          plugin_id: search_api_field
+        field_extent:
+          id: field_extent
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_extent
+          entity_type: node
+          plugin_id: search_api_field
+        field_featured_item:
+          id: field_featured_item
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_featured_item
+          entity_type: node
+          plugin_id: search_api_field
+        field_finding_aid:
+          id: field_finding_aid
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_finding_aid
+          entity_type: node
+          plugin_id: search_api_field
+        field_genre:
+          id: field_genre
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_genre
+          entity_type: node
+          plugin_id: search_api_field
+        field_geoportal_link:
+          id: field_geoportal_link
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_geoportal_link
+          entity_type: node
+          plugin_id: search_api_field
+        nid_1:
+          id: nid_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: nid
+          entity_type: node
+          plugin_id: search_api_field
+        field_is_part_of:
+          id: field_is_part_of
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_is_part_of
+          entity_type: node
+          plugin_id: search_api_field
+        field_issn:
+          id: field_issn
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_issn
+          entity_type: node
+          plugin_id: search_api_field
+        field_item_barcode:
+          id: field_item_barcode
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_item_barcode
+          entity_type: node
+          plugin_id: search_api_field
+        field_language:
+          id: field_language
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_language
+          entity_type: node
+          plugin_id: search_api_field
+        field_library_catalog_link:
+          id: field_library_catalog_link
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_library_catalog_link
+          entity_type: node
+          plugin_id: search_api_field
+        field_member_of_1:
+          id: field_member_of_1
+          table: search_api_index_default_solr_index
+          field: field_member_of
+          plugin_id: search_api_field
+        field_model:
+          id: field_model
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_model
+          entity_type: node
+          plugin_id: search_api_field
+        field_oclc_number:
+          id: field_oclc_number
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_oclc_number
+          entity_type: node
+          plugin_id: search_api_field
+        field_member_of_2:
+          id: field_member_of_2
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_member_of
+          entity_type: node
+          plugin_id: search_api_field
+        status:
+          id: status
+          table: search_api_datasource_default_solr_index_entity_node
+          field: status
+          entity_type: node
+          plugin_id: search_api_field
+        field_publisher:
+          id: field_publisher
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_publisher
+          entity_type: node
+          plugin_id: search_api_field
+        field_publisher_country:
+          id: field_publisher_country
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_publisher_country
+          entity_type: node
+          plugin_id: search_api_field
+        field_resource_type:
+          id: field_resource_type
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_resource_type
+          entity_type: node
+          plugin_id: search_api_field
+        field_spatial_coverage:
+          id: field_spatial_coverage
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_spatial_coverage
+          entity_type: node
+          plugin_id: search_api_field
+        field_subject:
+          id: field_subject
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_subject
+          entity_type: node
+          plugin_id: search_api_field
+        field_table_of_contents:
+          id: field_table_of_contents
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_table_of_contents
+          entity_type: node
+          plugin_id: search_api_field
+        title_1:
+          id: title_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: title
+          entity_type: node
+          plugin_id: search_api_field
+        field_title_language:
+          id: field_title_language
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_title_language
+          entity_type: node
+          plugin_id: search_api_field
+        uuid_1:
+          id: uuid_1
+          table: search_api_datasource_default_solr_index_entity_node
+          field: uuid
+          entity_type: node
+          plugin_id: search_api_field
+        field_years:
+          id: field_years
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_years
+          entity_type: node
+          plugin_id: search_api_field
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: input_required
+        options:
+          submit_button: Search
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: 'Please enter some keywords to search.'
+          text_input_required_format: basic_html
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: none
+        options: {  }
+      empty: {  }
+      sorts:
+        field_dspace_identifier:
+          id: field_dspace_identifier
+          table: search_api_index_default_solr_index
+          field: field_dspace_identifier
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            collection_object: collection_object
+            islandora_object: islandora_object
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_default_solr_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: 'Fulltext search'
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: query
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              fedoraadmin: '0'
+              staff: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: direct
+          min_length: null
+          fields: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: search_api
+        options:
+          view_modes:
+            'entity:node':
+              article: default
+              collection_object: teaser
+              islandora_object: teaser
+              page: default
+            'entity:taxonomy_term':
+              access_rights: default
+              copyright_and_use: default
+              corporate_body: default
+              family: default
+              genre: default
+              geo_location: default
+              language: default
+              person: default
+              resource_types: default
+              subject: default
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying results @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_abstract'
+        - 'config:field.storage.node.field_access_rights'
+        - 'config:field.storage.node.field_alternative_title'
+        - 'config:field.storage.node.field_citable_url'
+        - 'config:field.storage.node.field_collection_contact_name'
+        - 'config:field.storage.node.field_collection_number'
+        - 'config:field.storage.node.field_contributor'
+        - 'config:field.storage.node.field_copyright_and_use'
+        - 'config:field.storage.node.field_copyright_holder'
+        - 'config:field.storage.node.field_creator'
+        - 'config:field.storage.node.field_date_available'
+        - 'config:field.storage.node.field_date_copyrighted'
+        - 'config:field.storage.node.field_date_created'
+        - 'config:field.storage.node.field_date_published'
+        - 'config:field.storage.node.field_description'
+        - 'config:field.storage.node.field_digital_publisher'
+        - 'config:field.storage.node.field_extent'
+        - 'config:field.storage.node.field_featured_item'
+        - 'config:field.storage.node.field_finding_aid'
+        - 'config:field.storage.node.field_genre'
+        - 'config:field.storage.node.field_geoportal_link'
+        - 'config:field.storage.node.field_is_part_of'
+        - 'config:field.storage.node.field_issn'
+        - 'config:field.storage.node.field_item_barcode'
+        - 'config:field.storage.node.field_language'
+        - 'config:field.storage.node.field_library_catalog_link'
+        - 'config:field.storage.node.field_member_of'
+        - 'config:field.storage.node.field_model'
+        - 'config:field.storage.node.field_oclc_number'
+        - 'config:field.storage.node.field_publisher'
+        - 'config:field.storage.node.field_publisher_country'
+        - 'config:field.storage.node.field_resource_type'
+        - 'config:field.storage.node.field_spatial_coverage'
+        - 'config:field.storage.node.field_subject'
+        - 'config:field.storage.node.field_table_of_contents'
+        - 'config:field.storage.node.field_title_language'
+        - 'config:field.storage.node.field_years'
+        - 'config:search_api.index.default_solr_index'
+      cacheable: false
+  rest_export_1:
+    id: rest_export_1
+    display_title: 'REST export'
+    display_plugin: rest_export
+    position: 2
+    display_options:
+      fields:
+        field_dspace_identifier:
+          id: field_dspace_identifier
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_dspace_identifier
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: dspace_identifier
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 500
+            url_only: true
+            url_plain: true
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_citable_url:
+          id: field_citable_url
+          table: search_api_datasource_default_solr_index_entity_node
+          field: field_citable_url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: 'Citable URL'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: null
+            url_only: true
+            url_plain: true
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 500
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_default_solr_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: 'Fulltext search'
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: query
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              administrator: '0'
+              global_admin: '0'
+              collection_level_admin: '0'
+              fedoraadmin: '0'
+              anonymous: '0'
+            expose_fields: false
+            placeholder: ''
+            searched_fields_id: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: direct
+          min_length: null
+          fields: {  }
+        type:
+          id: type
+          table: search_api_index_default_solr_index
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value:
+            islandora_object: islandora_object
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        field_dspace_identifier:
+          id: field_dspace_identifier
+          table: search_api_index_default_solr_index
+          field: field_dspace_identifier
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_string
+        field_citable_url:
+          id: field_citable_url
+          table: search_api_index_default_solr_index
+          field: field_citable_url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: search_api_string
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: data_export
+        options:
+          formats:
+            csv: csv
+          csv_settings:
+            delimiter: ' '
+            enclosure: '"'
+            escape_char: \
+            strip_tags: false
+            trim: false
+            encoding: utf8
+            utf8_bom: '0'
+            use_serializer_encode_only: false
+      row:
+        type: data_field
+        options:
+          field_options:
+            search_api_excerpt:
+              alias: ''
+              raw_output: false
+            search_api_id:
+              alias: ''
+              raw_output: false
+            field_abstract:
+              alias: ''
+              raw_output: false
+            field_access_terms:
+              alias: ''
+              raw_output: false
+            field_access_rights:
+              alias: ''
+              raw_output: false
+            uid:
+              alias: ''
+              raw_output: false
+            created:
+              alias: ''
+              raw_output: false
+            field_citable_url:
+              alias: ''
+              raw_output: false
+            field_collection_contact_email:
+              alias: ''
+              raw_output: false
+            field_collection_contact_name:
+              alias: ''
+              raw_output: false
+            field_collection_number:
+              alias: ''
+              raw_output: false
+            type:
+              alias: ''
+              raw_output: false
+            field_contributor:
+              alias: ''
+              raw_output: false
+            field_copyright_and_use:
+              alias: ''
+              raw_output: false
+            field_copyright_holder:
+              alias: ''
+              raw_output: false
+            field_creator:
+              alias: ''
+              raw_output: false
+            field_date_copyrighted:
+              alias: ''
+              raw_output: false
+            field_date_created:
+              alias: ''
+              raw_output: false
+            field_date_published:
+              alias: ''
+              raw_output: false
+            field_digital_publisher:
+              alias: ''
+              raw_output: false
+            field_extent:
+              alias: ''
+              raw_output: false
+            field_featured_item:
+              alias: ''
+              raw_output: false
+            field_finding_aid:
+              alias: ''
+              raw_output: false
+            field_genre:
+              alias: ''
+              raw_output: false
+            field_geoportal_link:
+              alias: ''
+              raw_output: false
+            field_is_part_of:
+              alias: ''
+              raw_output: false
+            field_issn:
+              alias: ''
+              raw_output: false
+            field_item_barcode:
+              alias: ''
+              raw_output: false
+            field_language:
+              alias: ''
+              raw_output: false
+            field_library_catalog_link:
+              alias: ''
+              raw_output: false
+            field_model:
+              alias: ''
+              raw_output: false
+            field_oclc_number:
+              alias: ''
+              raw_output: false
+            status:
+              alias: ''
+              raw_output: false
+            field_publisher:
+              alias: ''
+              raw_output: false
+            field_publisher_country:
+              alias: ''
+              raw_output: false
+            field_resource_type:
+              alias: ''
+              raw_output: false
+            field_spatial_coverage:
+              alias: ''
+              raw_output: false
+            field_subject:
+              alias: ''
+              raw_output: false
+            field_table_of_contents:
+              alias: ''
+              raw_output: false
+            field_title_language:
+              alias: ''
+              raw_output: false
+            field_years:
+              alias: ''
+              raw_output: false
+            nid:
+              alias: ''
+              raw_output: false
+            uuid:
+              alias: ''
+              raw_output: false
+            field_member_of:
+              alias: ''
+              raw_output: false
+            title:
+              alias: ''
+              raw_output: false
+            field_alternative_title:
+              alias: ''
+              raw_output: false
+            field_date_available:
+              alias: ''
+              raw_output: false
+            field_description:
+              alias: ''
+              raw_output: false
+      defaults:
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: jscholarship_redirects_rest
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_citable_url'
+        - 'config:field.storage.node.field_dspace_identifier'
+        - 'config:search_api.index.default_solr_index'


### PR DESCRIPTION
This adds a View for exporting a file that is similar
to the format used by Apache's RewriteMap.

To access the endpoint for this view:

```
curl -X GET https://test.digital.library.jhu.edu/jscholarship_redirects_rest\?query=\(ss_type\:islandora_object\)\&items_per_page\=500\&offset\=0 > out.csv
```

That will only get the first 500 items. You'll want to use the offset parameter
to go through until you have exported metadata for all the items in the repo.

This would preferably be done in a script.

The resulting file will look like:

```
dspace_identifier "Citable URL"
https://jscholarship.library.jhu.edu/handle/1774.2/57496 https://test.digital.library.jhu.edu/node/5321
```

To use the resulting file as a RewriteMap the headers should be removed and the root URL
should be removed from the jscholarship URLS:

```
/handle/1774.2/57496 https://test.digital.library.jhu.edu/node/5321
```

Then in the JScholarship Apache config (after moving the file to `/etc/httpd/conf/redirects.txt`):

```
  RewriteEngine On
  RewriteMap redirects "txt:/etc/httpd/conf/redirects.txt"
  RewriteCond ${redirects:$1} !=""
  RewriteRule ^(.*)$ ${redirects:$1} [redirect=permanent,last]
```