### PR TITLE
Updates a comment containing empty snapshot tag

### DIFF
--- a/.env
+++ b/.env
@@ -78,7 +78,7 @@ SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319
 # Below is the clean snapshot that does not contain user content.
 # It only has the system terms located in the three system
 # taxonomies: Islandora Models, Islandora Display and Islandora Media Use.
-#SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630684249
+#SNAPSHOT_TAG=v0.1.0-empty
 
 # IdP, SP entity URIs and base URLs
 SP_BASEURL=https://islandora-idc.traefik.me


### PR DESCRIPTION
Very minor change - just updates the comment containing the empty snapshot tag with an easier and clearer tag. 

To test: verify that the [image exists](https://github.com/jhu-sheridan-libraries/idc-isle-dc/pkgs/container/idc-isle-dc%2Fsnapshot) and that the comment looks okay. 