### PR TITLE
Update solr to 8.11.1

### DIFF
--- a/.env
+++ b/.env
@@ -70,7 +70,7 @@ REPOSITORY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=upstream-20200824-f8d1e8e-71-g30d8b95
+TAG=upstream-20200824-f8d1e8e-75-gd9ecdf3
 
 # Docker image and tag for snapshot image
 SNAPSHOT_TAG=upstream-20201007-739693ae-405-g521b43f.1630614319


### PR DESCRIPTION
This incorporates @little9's upgrade of solr to 8.11.1 into iDC.   Going to version 8.11.1 should mitigate the log4j issues that arose last week.  I think we are okay with this version of Solr and protected from the lastest exploit (https://solr.apache.org/security.html#cve-2021-44548-apache-solr-information-disclosure-vulnerability-through-dataimporthandler).  

More information on the latest exploit: [ticket](https://issues.apache.org/jira/browse/LOG4J2-3230).  