### PR TITLE
Fix boolean operations in global search

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8074,12 +8074,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "0c323043b2b23ee625012fb7fe783e9840af97d1"
+                "reference": "278d7429171070788c96423847360ce7b48577b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/0c323043b2b23ee625012fb7fe783e9840af97d1",
-                "reference": "0c323043b2b23ee625012fb7fe783e9840af97d1",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/278d7429171070788c96423847360ce7b48577b8",
+                "reference": "278d7429171070788c96423847360ce7b48577b8",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8089,7 +8089,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/main",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2021-11-16T21:12:47+00:00"
+            "time": "2021-12-21T20:00:06+00:00"
         },
         {
             "name": "jhu-idc/idc_defaults",

--- a/end-to-end/tests/ui/advanced-search.spec.js
+++ b/end-to-end/tests/ui/advanced-search.spec.js
@@ -149,3 +149,36 @@ test('Date filter will reset current page', async (t) => {
     .expect(pager.pager.withText('5 of 5 items').exists).ok();
 
 });
+
+/**
+ * Try a manually entered boolean query inside the advanced search
+ *
+ * Expected search: ?query="plastic material"~10 OR (test) NOT (item AND rendering)
+ */
+test('Compound boolean search', async (t) => {
+  const term1 = Page.queryTerm(0);
+
+  await t
+    .click(term1.proxy)
+    .typeText(term1.proxyTerm.termA, 'plastic', { paste: true, replace: true})
+    .typeText(term1.proxyTerm.range, '10', { paste: true, replace: true})
+    .typeText(term1.proxyTerm.termB, 'material', { paste: true, replace: true});
+
+  const term2 = Page.queryTerm(1);
+
+  await t
+    .click(term2.opOr)
+    .typeText(term2.nonproxyTerm.term, 'test', { paste: true, replace: true});
+
+  const term3 = Page.queryTerm(2);
+
+  await t
+    .click(term3.opNot)
+    .typeText(term3.nonproxyTerm.term, 'item AND rendering', { paste: true, replace: true});
+
+  await t
+    .click(Page.submitBtn)
+    .expect(Page.results.count).eql(5)
+    .expect(Page.results.withText('A video item').exists).notOk()
+    .expect(Page.results.withText('rubber duck').exists).ok();
+});

--- a/end-to-end/tests/ui/collection-details.spec.js
+++ b/end-to-end/tests/ui/collection-details.spec.js
@@ -58,6 +58,15 @@ test('Shows both collections and repo items', async (t) => {
     .expect(Page.results.withText('Mallard').exists).ok();
 });
 
+test('Boolean operators still work as expected', async (t) => {
+  await t
+    .typeText(Page.searchInput, 'wild OR plastic', { paste: true, replace: true })
+    .click(Page.searchSubmit)
+    .expect(Page.results.count).eql(2)
+    // The two items should be present, but not the sub collection
+    .expect(Page.results.withText('SubDuck Collection').exists).notOk();
+});
+
 test('Facet toggle', async (t) => {
   await t.expect(Page.facetCategories.count).eql(3);
 

--- a/end-to-end/tests/ui/global-search.spec.js
+++ b/end-to-end/tests/ui/global-search.spec.js
@@ -1,0 +1,30 @@
+import GlobalSearch from './pages/global-search';
+import Results from './pages/searchable';
+
+fixture`Global Search`
+  .page`https://islandora-idc.traefik.me`;
+
+test('A basic single word search', async (t) => {
+  await GlobalSearch.search('duck', t);
+  await t.expect(Results.results.count).eql(4);
+});
+
+test('Boolean search: "yellow AND duck"', async (t) => {
+  await GlobalSearch.search('yellow AND duck', t);
+  await t.expect(Results.results.count).eql(1);
+});
+
+test('Boolean search: "s3 OR duck"', async (t) => {
+  await GlobalSearch.search('s3 OR duck', t);
+  await t.expect(Results.results.count).eql(6);
+});
+
+test('Simple wildcard search with "*"', async (t) => {
+  await GlobalSearch.search('test*', t);
+  await t.expect(Results.results.count).eql(5);
+});
+
+test('Use of double quotes to search exact phrase: "Copyright Undetermined"', async (t) => {
+  await GlobalSearch.search('"Copyright Undetermined"', t);
+  await t.expect(Results.results.count).eql(4);
+});

--- a/end-to-end/tests/ui/global-search.spec.js
+++ b/end-to-end/tests/ui/global-search.spec.js
@@ -9,7 +9,7 @@ test('A basic single word search', async (t) => {
   await t.expect(Results.results.count).eql(4);
 });
 
-test('Boolean search: "yellow AND duck"', async (t) => {
+test('Boolean search: "duck AND yellow"', async (t) => {
   await GlobalSearch.search('yellow AND duck', t);
   await t.expect(Results.results.count).eql(1);
 });
@@ -19,12 +19,28 @@ test('Boolean search: "s3 OR duck"', async (t) => {
   await t.expect(Results.results.count).eql(6);
 });
 
-test('Simple wildcard search with "*"', async (t) => {
+test('Simple wildcard with "*": "test*"', async (t) => {
   await GlobalSearch.search('test*', t);
   await t.expect(Results.results.count).eql(5);
 });
 
+test('Simple windcard with "?": "te?t"', async (t) => {
+  await GlobalSearch.search('te?t', t);
+  await t.expect(Results.results.count).eql(6);
+});
+
 test('Use of double quotes to search exact phrase: "Copyright Undetermined"', async (t) => {
+  // This should omit items marked as "In Copyright" for example
   await GlobalSearch.search('"Copyright Undetermined"', t);
   await t.expect(Results.results.count).eql(4);
+});
+
+test('Compound search: "(duck AND toy) OR goat"', async (t) => {
+  await GlobalSearch.search('(duck AND toy) OR goat', t);
+  await t.expect(Results.results.count).eql(2);
+});
+
+test('Proximity search: \'"test render"~3\'', async (t) => {
+  await GlobalSearch.search('"test render"~3', t);
+  await t.expect(Results.results.count).eql(1);
 });

--- a/end-to-end/tests/ui/pages/global-search.js
+++ b/end-to-end/tests/ui/pages/global-search.js
@@ -1,0 +1,20 @@
+import { Selector } from 'testcafe';
+
+export class GlobalSearch {
+  constructor() {
+    this.container = Selector('header #block-idcsearchblock');
+
+    this.input = this.container.find('input[type="text"]');
+    this.submitBtn = this.container.find('input[type="submit"]');
+
+    this.advancedSearchLink = this.container.find('a');
+  }
+
+  async search(term, testcafe) {
+    return await testcafe
+      .typeText(this.input, term, { paste: true, replace: true })
+      .click(this.submitBtn);
+  }
+}
+
+export default new GlobalSearch();


### PR DESCRIPTION
* Don't parse `?query` URL parameter while initializing the search UI, since it's not necessary and causing bugs. 
(Tests will be added to `idc-isle-dc` for global search.)
* Surround user-entered search term(s) with parentheses to avoid clash with page level filters (node and type filters)
* Update the help text (on the Advanced Search page) describing query syntax and special characters

Comments noted in the old `#parseSolrQuery` function don't apply to the query that is parsed. This function seems to have been originally intended to parse the query that is passed to Solr, although its ultimate use was to parse the query parameter of the search page, which doesn't require the same level of parsing.

Use entered search terms are now surrounded by parentheses in order to apply as expected along side page level filters, such as the node filter on a collection details page. Order-of-operations could get weird without the parentheses leading to weird search behaviors. This will lead to uglier Solr queries, such as `?query="plastic material"~10 OR (test) NOT (item AND rendering)` (first example below). Note the middle keyword: test term is just the word **test** in parentheses. While this doesn't look great in the Solr query, it functions fine and requires zero logic to decide when to apply the parentheses.

----

Some examples of searches covered by these changes:

* Advanced search: 
![image](https://user-images.githubusercontent.com/5167587/146833213-0d73cc2a-ba73-4c06-84f6-e20bf719e752.png)
* Collection details page: 
![image](https://user-images.githubusercontent.com/5167587/146833330-8ea70b9c-8b71-4e0a-a91e-75cdf37d1e91.png)
* Global search: 
![image](https://user-images.githubusercontent.com/5167587/146833550-0f4b2049-c50f-4391-840d-742239a2ef41.png)
