### PR TITLE
Fixes issue where Media name was changed on re-ingest

### DIFF
--- a/codebase/config/sync/media.type.audio.yml
+++ b/codebase/config/sync/media.type.audio.yml
@@ -16,6 +16,5 @@ new_revision: true
 source_configuration:
   source_field: field_media_audio_file
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size

--- a/codebase/config/sync/media.type.document.yml
+++ b/codebase/config/sync/media.type.document.yml
@@ -16,6 +16,5 @@ new_revision: true
 source_configuration:
   source_field: field_media_document
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size

--- a/codebase/config/sync/media.type.file.yml
+++ b/codebase/config/sync/media.type.file.yml
@@ -16,6 +16,5 @@ new_revision: true
 source_configuration:
   source_field: field_media_file
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size

--- a/codebase/config/sync/media.type.fits_technical_metadata.yml
+++ b/codebase/config/sync/media.type.fits_technical_metadata.yml
@@ -16,6 +16,5 @@ new_revision: false
 source_configuration:
   source_field: field_media_file
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size

--- a/codebase/config/sync/media.type.image.yml
+++ b/codebase/config/sync/media.type.image.yml
@@ -16,7 +16,6 @@ new_revision: true
 source_configuration:
   source_field: field_media_image
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size
   width: field_width

--- a/codebase/config/sync/media.type.remote_video.yml
+++ b/codebase/config/sync/media.type.remote_video.yml
@@ -16,5 +16,4 @@ source_configuration:
     - YouTube
     - Vimeo
   source_field: field_media_oembed_video
-field_map:
-  title: name
+field_map: {  }

--- a/codebase/config/sync/media.type.video.yml
+++ b/codebase/config/sync/media.type.video.yml
@@ -16,6 +16,5 @@ new_revision: true
 source_configuration:
   source_field: field_media_video_file
 field_map:
-  name: name
   mimetype: field_mime_type
   filesize: field_file_size

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -387,3 +387,137 @@ test('Perform Media Migrations', async t => {
 
 });
 
+// This test just runs the same migrations as the above test.
+// The GO code was already checking the media files to ensure that
+// they were ingested correct and that the data was fine.
+// What the below proves is that running a media ingest more than once
+// does not change the data, providing the GO code test for
+// the data still passes.
+// Admittedly the flow is a little awkward, because I can't depend on the
+// last test being run first, so I put two migrations for each media type in here
+// By the time the GO code runs, the media migrations will have been run 3 times.
+// Should there be any issues with re-running ingests, it will show up when the GO
+// code checks the data.
+test('Duplicate Media Migrations', async t => {
+
+  // Migrate Islandora Access Terms for media tests
+  await doMigration(
+    t,
+    migrate_islandora_accessterms_taxonomy,
+    './migrations/media-accessterms.csv'
+  );
+
+  // Migrate access rights
+  await doMigration(
+    t,
+    migrate_accessrights_taxonomy,
+    './migrations/media-accessrights.csv'
+  );
+
+  // Migrate media subjects
+  await doMigration(
+    t,
+    migrate_subject_taxonomy,
+    './migrations/media-subjects.csv'
+  );
+
+  // Migrate the Collection and Repository Object the Media will be attached to
+  await doMigration(
+    t,
+    migrate_new_collection,
+    './migrations/media-collection.csv'
+  );
+
+  await doMigration(
+    t,
+    migrate_new_items,
+    './migrations/media-islandora_object.csv'
+  );
+
+  // just run the media migrations twice, we will check the results in the verifcation step. 
+  // audio
+  await doMigration(
+    t,
+    migrate_media_audio,
+    './migrations/media-audio.csv'
+  );
+
+  await doMigration(
+    t,
+    migrate_media_audio,
+    './migrations/media-audio.csv'
+  );
+
+  // document
+  await doMigration(
+    t,
+    migrate_media_document,
+    './migrations/media-document.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_document,
+    './migrations/media-document.csv'
+  );
+
+  // extracted text
+  await doMigration(
+    t,
+    migrate_media_extracted_text,
+    './migrations/media-extracted_text.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_extracted_text,
+    './migrations/media-extracted_text.csv'
+  );
+
+  // file
+  await doMigration(
+    t,
+    migrate_media_file,
+    './migrations/media-file.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_file,
+    './migrations/media-file.csv'
+  );
+
+  // image
+  await doMigration(
+    t,
+    migrate_media_image,
+    './migrations/media-image.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_image,
+    './migrations/media-image.csv'
+  );
+
+  // video
+  await doMigration(
+    t,
+    migrate_media_video,
+    './migrations/media-video.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_video,
+    './migrations/media-video.csv'
+  );
+
+  // remote video
+  await doMigration(
+    t,
+    migrate_media_remote_video,
+    './migrations/media-remote_video.csv'
+  );
+  await doMigration(
+    t,
+    migrate_media_remote_video,
+    './migrations/media-remote_video.csv'
+  );
+});
+

--- a/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
+++ b/tests/10-migration-backend-tests/testcafe/migrate_tests.spec.js
@@ -387,17 +387,6 @@ test('Perform Media Migrations', async t => {
 
 });
 
-// This test just runs the same migrations as the above test.
-// The GO code was already checking the media files to ensure that
-// they were ingested correct and that the data was fine.
-// What the below proves is that running a media ingest more than once
-// does not change the data, providing the GO code test for
-// the data still passes.
-// Admittedly the flow is a little awkward, because I can't depend on the
-// last test being run first, so I put two migrations for each media type in here
-// By the time the GO code runs, the media migrations will have been run 3 times.
-// Should there be any issues with re-running ingests, it will show up when the GO
-// code checks the data.
 test('Duplicate Media Migrations', async t => {
 
   // Migrate Islandora Access Terms for media tests
@@ -434,90 +423,87 @@ test('Duplicate Media Migrations', async t => {
     './migrations/media-islandora_object.csv'
   );
 
-  // just run the media migrations twice, we will check the results in the verifcation step. 
   // audio
   await doMigration(
     t,
     migrate_media_audio,
-    './migrations/media-audio.csv'
+    './migrations/media-audio-multi.csv'
   );
-
   await doMigration(
     t,
     migrate_media_audio,
-    './migrations/media-audio.csv'
+    './migrations/media-audio-multi.csv'
   );
 
   // document
   await doMigration(
     t,
     migrate_media_document,
-    './migrations/media-document.csv'
+    './migrations/media-document-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_document,
-    './migrations/media-document.csv'
+    './migrations/media-document-multi.csv'
   );
 
   // extracted text
   await doMigration(
     t,
     migrate_media_extracted_text,
-    './migrations/media-extracted_text.csv'
+    './migrations/media-extracted_text-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_extracted_text,
-    './migrations/media-extracted_text.csv'
+    './migrations/media-extracted_text-multi.csv'
   );
 
   // file
   await doMigration(
     t,
     migrate_media_file,
-    './migrations/media-file.csv'
+    './migrations/media-file-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_file,
-    './migrations/media-file.csv'
+    './migrations/media-file-multi.csv'
   );
 
   // image
   await doMigration(
     t,
     migrate_media_image,
-    './migrations/media-image.csv'
+    './migrations/media-image-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_image,
-    './migrations/media-image.csv'
+    './migrations/media-image-multi.csv'
   );
 
   // video
   await doMigration(
     t,
     migrate_media_video,
-    './migrations/media-video.csv'
+    './migrations/media-video-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_video,
-    './migrations/media-video.csv'
+    './migrations/media-video-multi.csv'
   );
 
-  // remote video
   await doMigration(
     t,
     migrate_media_remote_video,
-    './migrations/media-remote_video.csv'
+    './migrations/media-remote_video-multi.csv'
   );
   await doMigration(
     t,
     migrate_media_remote_video,
-    './migrations/media-remote_video.csv'
+    './migrations/media-remote_video-multi.csv'
   );
 });
 

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-audio-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-audio-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access,new_filename
+media_audio_m_00001,Moo Cow Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,moo.mp3,audio/mpeg,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/audio/moo.mp3,1,moo-multi.mp3

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-document-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-document-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access,new_filename
+media_doc_m_00001,Fuji Acros Datasheet Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,Fuji_acros.pdf,application/pdf,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/document/Fuji_acros.pdf,0,Fuji_acros-multi.pdf

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-extracted_text-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,mime_type,media_of,media_use,url,restricted_access,new_filename
+media_ext_m_00001,Hello World Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,text/plain,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/extracted_text/hello_world.txt,1,hello_world-multi.txt

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-file-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-file-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access,new_filename
+media_file_m_00001,Geo Tif file Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,NEFF1851_GEO.tfw,application/octet-stream,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/file/NEFF1851_GEO.tfw,1,NEFF1851_GEO-multi.tfw

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-image-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-image-multi.csv
@@ -1,0 +1,3 @@
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,alt_text,restricted_access,new_filename
+media_img_m_00001,Looking For Fossils Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,TRP_7767.jpg,image/jpeg,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/image/TRP_7767.jpg,Image alt text,0,TRP_7767-multi.jpg
+media_format_file_tiff_m_01,Tiff Image Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,tiff.tif,image/tiff,:::media_io_1,Original File,http://migration-assets/assets/image/formats/tiff.tif,tiff,1,tiff-multi.tiff

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-remote_video-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-remote_video-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,media_of,url,restricted_access
+media_rvideo_m_00001,A Tour of Go Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,:::media_io_1,https://www.youtube.com/watch?v=ytEkHepK08c,1

--- a/tests/10-migration-backend-tests/testcafe/migrations/media-video-multi.csv
+++ b/tests/10-migration-backend-tests/testcafe/migrations/media-video-multi.csv
@@ -1,0 +1,2 @@
+unique_id,name,access_terms,original_name,mime_type,media_of,media_use,url,restricted_access,new_filename
+media_video_m_00001,Chair Pop Video Multi,:::media_accesscontrol_01||:::media_accesscontrol_02,chair-pop-gif.mp4,video/mp4,:::media_io_1,Original File||Preservation File,http://migration-assets/assets/video/chair-pop-gif.mp4,1,chair-pop-gif-multi.mp4

--- a/tests/10-migration-backend-tests/verification/expected/media-audio-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-audio-multi.json
@@ -1,0 +1,19 @@
+{
+  "type": "media",
+  "bundle": "audio",
+  "name": "Moo Cow Multi",
+  "unique_id": "media_audio_m_00001",
+  "original_name": "moo.mp3",
+  "size": 82539,
+  "mime_type": "audio/mpeg",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One"
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-document-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-document-multi.json
@@ -1,0 +1,19 @@
+{
+  "type": "media",
+  "bundle": "document",
+  "name": "Fuji Acros Datasheet Multi",
+  "unique_id": "media_doc_m_00001",
+  "original_name": "Fuji_acros.pdf",
+  "size": 98884,
+  "mime_type": "application/pdf",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One"
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-extracted_text-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-extracted_text-multi.json
@@ -1,0 +1,24 @@
+{
+  "type": "media",
+  "bundle": "extracted_text",
+  "name": "Hello World Multi",
+  "unique_id": "media_ext_m_00001",
+  "original_name": "hello_world.txt",
+  "size": 29,
+  "mime_type": "text/plain",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One",
+  "extracted_text": {
+    "value": "Hello, extracted text world!<br />\n",
+    "format": "basic_html",
+    "processed": "Hello, extracted text world!<br />"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-file-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-file-multi.json
@@ -1,0 +1,19 @@
+{
+  "type": "media",
+  "bundle": "file",
+  "name": "Geo Tif file Multi",
+  "unique_id": "media_file_m_00001",
+  "original_name": "NEFF1851_GEO.tfw",
+  "size": 44,
+  "mime_type": "application/octet-stream",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One"
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-image-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-image-multi.json
@@ -1,0 +1,26 @@
+{
+  "type": "media",
+  "bundle": "image",
+  "name": "Looking For Fossils Multi",
+  "unique_id": "media_img_m_00001",
+  "original_name": "TRP_7767.jpg",
+  "alt_text": "Image alt text",
+  "size": 7584545,
+  "height": 2239,
+  "width": 3378,
+  "mime_type": "image/jpeg",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One",
+  "uri": {
+    "url": "/system/files/2021-03/trp_7767-multi_0.jpg",
+    "value": "private://2021-03/trp_7767-multi_0.jpg"
+  }
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-remote_video-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-remote_video-multi.json
@@ -1,0 +1,13 @@
+{
+  "type": "media",
+  "bundle": "remote_video",
+  "name": "A Tour of Go Multi",
+  "restricted_access": true,
+  "unique_id": "media_rvideo_m_00001",
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One",
+  "embed_url": "https://www.youtube.com/watch?v=ytEkHepK08c"
+}

--- a/tests/10-migration-backend-tests/verification/expected/media-video-multi.json
+++ b/tests/10-migration-backend-tests/verification/expected/media-video-multi.json
@@ -1,0 +1,19 @@
+{
+  "type": "media",
+  "bundle": "video",
+  "name": "Chair Pop Video Multi",
+  "unique_id": "media_video_m_00001",
+  "original_name": "chair-pop-gif.mp4",
+  "size": 214707,
+  "mime_type": "video/mp4",
+  "restricted_access": true,
+  "use": [
+    "Preservation File",
+    "Original File"
+  ],
+  "access_terms": [
+    "Media Group B",
+    "Media Group A"
+  ],
+  "media_of": "Media Migration Repository Item One"
+}

--- a/tests/10-migration-backend-tests/verification/verify_migrations_test.go
+++ b/tests/10-migration-backend-tests/verification/verify_migrations_test.go
@@ -1729,6 +1729,480 @@ func Test_VerifyMediaRemoteVideo(t *testing.T) {
 	//assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
 }
 
+//---------- Check multiple ingests of media files ------
+// These next set of tests test what happens when you run a media
+// ingest a few times. They end result should be the same, overall
+//
+func Test_VerifyMediaDocumentMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaGeneric{}
+	unmarshalExpectedJson(t, "media-document-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, "media", expectedJson.Type)
+	assert.Equal(t, "document", expectedJson.Bundle)
+
+	// There are two media with name that were migrated by testcafe
+	name := "Fuji Acros Datasheet Multi"
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: "media",
+		DrupalBundle: "document",
+		Filter:       "name",
+		Value:        name,
+	}
+
+	res := model.JsonApiDocumentMedia{}
+	u.Get(&res)
+
+	// use the first media
+	document := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Size, document.JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, document.JsonApiAttributes.MimeType)
+	assert.Equal(t, expectedJson.OriginalName, document.JsonApiAttributes.OriginalName)
+	assert.Equal(t, expectedJson.Name, document.JsonApiAttributes.Name)
+	assert.NotEqual(t, expectedJson.RestrictedAccess, document.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, document.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(document.JsonApiRelationships.AccessTerms.Data))
+	for i := range document.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		document.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(document.JsonApiRelationships.MediaUse.Data))
+	for i := range document.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		document.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Equal(t, expectedJson.MediaUse[i], use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	document.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	document.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+}
+
+func Test_VerifyMediaImageMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaImage{}
+	unmarshalExpectedJson(t, "media-image-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, "media", expectedJson.Type)
+	assert.Equal(t, "image", expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: "media",
+		DrupalBundle: "image",
+		Filter:       "name",
+		Value:        "Looking For Fossils Multi",
+	}
+
+	res := model.JsonApiImageMedia{}
+	u.GetSingle(&res)
+
+	// use the first media
+	image := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Size, image.JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, image.JsonApiAttributes.MimeType)
+	assert.Equal(t, expectedJson.OriginalName, image.JsonApiAttributes.OriginalName)
+	assert.Equal(t, expectedJson.Name, image.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.Height, image.JsonApiAttributes.Height)
+	assert.Equal(t, expectedJson.Width, image.JsonApiAttributes.Width)
+	assert.NotEqual(t, expectedJson.RestrictedAccess, image.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, image.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(image.JsonApiRelationships.AccessTerms.Data))
+	for i := range image.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		image.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, expectedJson.AltText, image.JsonApiRelationships.File.Data.Meta["alt"])
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(image.JsonApiRelationships.MediaUse.Data))
+	for i := range image.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		image.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Equal(t, expectedJson.MediaUse[i], use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	image.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	u = &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: "media",
+		DrupalBundle: "image",
+		Filter:       "name",
+		Value:        "Tiff Image Multi",
+	}
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	image.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+
+	res2 := model.JsonApiImageMedia{}
+	u.GetSingle(&res2)
+
+	image2 := res2.JsonApiData[0]
+
+	assert.Equal(t, expectedJson.RestrictedAccess, image2.JsonApiAttributes.RestrictedAccess)
+
+	file2 := model.JsonApiFile{}
+	res2.JsonApiData[0].JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file2, drupalAdmin, drupalPass)
+
+	// check that the first file binary can be accessed where its media is restricted access == false
+	// TODO obtain from env
+	baseUri := "https://islandora-idc.traefik.me"
+	fileUrl := fmt.Sprintf("%s%s", baseUri, file.JsonApiData[0].JsonApiAttributes.Uri.Url)
+	fileRes, err := http.Get(fileUrl)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "200 OK", fileRes.Status)
+
+    // check that the second file binary cannot be accessed where its media is restricted access == true
+    fileUrl = fmt.Sprintf("%s%s", baseUri, file2.JsonApiData[0].JsonApiAttributes.Uri.Url)
+    fileRes, err = http.Get(fileUrl)
+	assert.Nil(t, err)
+	assert.Equal(t, "403 Forbidden", fileRes.Status)
+}
+
+func Test_VerifyMediaExtractedTextMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaExtractedText{}
+	expectedType := "media"
+	expectedBundle := "extracted_text"
+	unmarshalExpectedJson(t, "media-extracted_text-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, expectedType, expectedJson.Type)
+	assert.Equal(t, expectedBundle, expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: expectedType,
+		DrupalBundle: expectedBundle,
+		Filter:       "name",
+		Value:        expectedJson.Name,
+	}
+
+	res := model.JsonApiExtractedTextMedia{}
+	u.GetSingle(&res)
+	ext := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Name, ext.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.MimeType, ext.JsonApiAttributes.MimeType)
+	assert.EqualValues(t, expectedJson.ExtractedText, ext.JsonApiAttributes.EditedText)
+	assert.Equal(t, expectedJson.RestrictedAccess, ext.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, ext.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(ext.JsonApiRelationships.AccessTerms.Data))
+	for i := range ext.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		ext.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(ext.JsonApiRelationships.MediaUse.Data))
+	for i := range ext.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		ext.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Equal(t, expectedJson.MediaUse[i], use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	ext.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	ext.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+}
+
+func Test_VerifyMediaFileMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaGeneric{}
+	expectedType := "media"
+	expectedBundle := "file"
+	unmarshalExpectedJson(t, "media-file-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, expectedType, expectedJson.Type)
+	assert.Equal(t, expectedBundle, expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: expectedType,
+		DrupalBundle: expectedBundle,
+		Filter:       "name",
+		Value:        expectedJson.Name,
+	}
+
+	res := model.JsonApiGenericFileMedia{}
+	u.GetSingle(&res)
+	genericFile := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Name, genericFile.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.MimeType, genericFile.JsonApiAttributes.MimeType)
+	assert.EqualValues(t, expectedJson.OriginalName, genericFile.JsonApiAttributes.OriginalName)
+	assert.Equal(t, expectedJson.Size, genericFile.JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.RestrictedAccess, genericFile.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, genericFile.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(genericFile.JsonApiRelationships.AccessTerms.Data))
+	for i := range genericFile.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		genericFile.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(genericFile.JsonApiRelationships.MediaUse.Data))
+	for i := range genericFile.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		genericFile.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.MediaUse, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	genericFile.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	genericFile.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+}
+
+func Test_VerifyMediaAudioMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaGeneric{}
+	expectedType := "media"
+	expectedBundle := "audio"
+	unmarshalExpectedJson(t, "media-audio-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, expectedType, expectedJson.Type)
+	assert.Equal(t, expectedBundle, expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: expectedType,
+		DrupalBundle: expectedBundle,
+		Filter:       "name",
+		Value:        expectedJson.Name,
+	}
+
+	res := model.JsonApiAudioMedia{}
+	u.GetSingle(&res)
+	audio := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Name, audio.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.MimeType, audio.JsonApiAttributes.MimeType)
+	assert.EqualValues(t, expectedJson.OriginalName, audio.JsonApiAttributes.OriginalName)
+	assert.Equal(t, expectedJson.Size, audio.JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.RestrictedAccess, audio.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, audio.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(audio.JsonApiRelationships.AccessTerms.Data))
+	for i := range audio.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		audio.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(audio.JsonApiRelationships.MediaUse.Data))
+	for i := range audio.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		audio.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Equal(t, expectedJson.MediaUse[i], use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	audio.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	audio.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+}
+
+func Test_VerifyMediaVideoMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaGeneric{}
+	expectedType := "media"
+	expectedBundle := "video"
+	unmarshalExpectedJson(t, "media-video-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, expectedType, expectedJson.Type)
+	assert.Equal(t, expectedBundle, expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: expectedType,
+		DrupalBundle: expectedBundle,
+		Filter:       "name",
+		Value:        expectedJson.Name,
+	}
+
+	res := model.JsonApiVideoMedia{}
+	u.GetSingle(&res)
+	video := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Name, video.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.MimeType, video.JsonApiAttributes.MimeType)
+	assert.EqualValues(t, expectedJson.OriginalName, video.JsonApiAttributes.OriginalName)
+	assert.Equal(t, expectedJson.Size, video.JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.RestrictedAccess, video.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, video.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	assert.Equal(t, 2, len(expectedJson.AccessTerms))
+	assert.Equal(t, len(expectedJson.AccessTerms), len(video.JsonApiRelationships.AccessTerms.Data))
+	for i := range video.JsonApiRelationships.AccessTerms.Data {
+		use := model.JsonApiIslandoraAccessTerms{}
+		video.JsonApiRelationships.AccessTerms.Data[i].Resolve(t, &use)
+		assert.Contains(t, expectedJson.AccessTerms, use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	assert.Equal(t, 2, len(expectedJson.MediaUse))
+	assert.Equal(t, len(expectedJson.MediaUse), len(video.JsonApiRelationships.MediaUse.Data))
+	for i := range video.JsonApiRelationships.MediaUse.Data {
+		use := model.JsonApiMediaUse{}
+		video.JsonApiRelationships.MediaUse.Data[i].Resolve(t, &use)
+		assert.Equal(t, expectedJson.MediaUse[i], use.JsonApiData[0].JsonApiAttributes.Name)
+	}
+
+	mediaOf := model.JsonApiIslandoraObj{}
+	video.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+
+	index := strings.Index(expectedJson.OriginalName, ".")
+	expectedFilename := expectedJson.OriginalName[:index] + "-multi_0" + expectedJson.OriginalName[index:]
+
+    file := model.JsonApiFile{}
+	video.JsonApiRelationships.File.Data.ResolveWithBasicAuth(t, &file, drupalAdmin, drupalPass)
+	verifyExpectedUri(t, file.JsonApiData[0].JsonApiAttributes.Uri.Url, file.JsonApiData[0].JsonApiAttributes.Uri.Value, 
+		expectedFilename, file.JsonApiData[0].JsonApiAttributes.CreatedDate)
+	assert.Equal(t, expectedJson.Size, file.JsonApiData[0].JsonApiAttributes.FileSize)
+	assert.Equal(t, expectedJson.MimeType, file.JsonApiData[0].JsonApiAttributes.MimeType)
+}
+
+func Test_VerifyMediaRemoteVideoMultipleIngests(t *testing.T) {
+	expectedJson := &model.ExpectedMediaRemoteVideo{}
+	expectedType := "media"
+	expectedBundle := "remote_video"
+	unmarshalExpectedJson(t, "media-remote_video-multi.json", &expectedJson)
+
+	// sanity check the expected json
+	assert.Equal(t, expectedType, expectedJson.Type)
+	assert.Equal(t, expectedBundle, expectedJson.Bundle)
+
+	u := &jsonapi.JsonApiUrl{
+		T:            t,
+		BaseUrl:      DrupalBaseurl,
+		DrupalEntity: expectedType,
+		DrupalBundle: expectedBundle,
+		Filter:       "name",
+		Value:        expectedJson.Name,
+	}
+
+	res := model.JsonApiRemoteVideoMedia{}
+	u.GetSingle(&res)
+	video := res.JsonApiData[0]
+
+	// Verify attributes
+
+	assert.Equal(t, expectedJson.Name, video.JsonApiAttributes.Name)
+	assert.Equal(t, expectedJson.EmbedUrl, video.JsonApiAttributes.EmbedUrl)
+	assert.Equal(t, expectedJson.RestrictedAccess, video.JsonApiAttributes.RestrictedAccess)
+	assert.Equal(t, expectedJson.UniqueId, video.JsonApiAttributes.UniqueId)
+
+	// Resolve relationships and verify
+
+	// TODO: media_of not supported for remote_video?
+	//mediaOf := JsonApiIslandoraObj{}
+	//video.JsonApiRelationships.MediaOf.Data.Resolve(t, &mediaOf)
+	//assert.Equal(t, expectedJson.MediaOf, mediaOf.JsonApiData[0].JsonApiAttributes.Title)
+}
+//
+// -- done checking media ingests performed more than once ------
+//
+
 // Locates the requested JSON file under the test directory, and unmarshals it into the interface supplied by `value`.
 func unmarshalExpectedJson(t *testing.T, fileName string, value interface{}) {
 	// TODO: use go:embed


### PR DESCRIPTION
When you change the source file on a Media (as a re-ingest does), the system will replace the Media's name with the filename.  I was able to see this in the system even w/o a re-ingest. All you had to do was edit a Media - remove the file and add a new one. Then when you saved the Media, its name would be replaced with the filename.  Turns out there is a configuration switch for that, so I just turned it off for Name.  Now when you re-ingest a media, the name of the media should stay the same, though other fields will get updated appropriately with the file's information (height/width/filesize/whatnot). 

To test this - simply do a Media ingest.  Then run the same one again and verify that the Media's name did not change. 

This resolves https://github.com/jhu-idc/idc-isle-dc/issues/271