### PR TITLE
Fix services mapping in docker-compose.env.yml

### DIFF
--- a/docker-compose.env.yml
+++ b/docker-compose.env.yml
@@ -59,8 +59,8 @@ services:
       ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS: ${ALPACA_HTTP_CONNECTION_REQUEST_TIMEOUT_MS:-7200000}
       ALPACA_HTTP_CONNECT_TIMEOUT_MS: ${ALPACA_HTTP_CONNECT_TIMEOUT_MS:-7200000}
       ALPACA_HTTP_SOCKET_TIMEOUT_MS: ${ALPACA_HTTP_SOCKET_TIMEOUT_MS:-7200000}
-  cantaloupe:
-    # No environment variables require overriding.
+  # cantaloupe: 
+  # No environment variables require overriding.
   mariadb:
     environment:
       #
@@ -327,5 +327,5 @@ services:
     environment:
       MINIO_ACCESS_KEY: ${DRUPAL_DEFAULT_S3_ACCESS_KEY}
       MINIO_SECRET_KEY: ${DRUPAL_DEFAULT_S3_SECRET_KEY}
-  solr:
-    # No environment variables require overriding.
+  # solr:
+  # No environment variables require overriding.


### PR DESCRIPTION
Solr and Cantaloupe's entries are blank in this file
and have a comment. When running `make` on a fresh
checkout of the code you may get this error:

`services.solr` must be a mapping

This changes those invalid blank entries so that they are
just comments.