### PR TITLE
Fix media rendering on item detail page

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8074,12 +8074,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "bd303f884c908ea17bc7a1aefeb0f584ccc97f7c"
+                "reference": "73aa7322b515f171aa949c1c59330f05d71b93da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/bd303f884c908ea17bc7a1aefeb0f584ccc97f7c",
-                "reference": "bd303f884c908ea17bc7a1aefeb0f584ccc97f7c",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/73aa7322b515f171aa949c1c59330f05d71b93da",
+                "reference": "73aa7322b515f171aa949c1c59330f05d71b93da",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8089,7 +8089,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/main",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2022-02-08T17:00:16+00:00"
+            "time": "2022-02-15T20:02:46+00:00"
         },
         {
             "name": "jhu-idc/idc_defaults",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8074,12 +8074,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc-ui-theme.git",
-                "reference": "73aa7322b515f171aa949c1c59330f05d71b93da"
+                "reference": "245ef906440e78e540975dcbca88fbe9b96849b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/73aa7322b515f171aa949c1c59330f05d71b93da",
-                "reference": "73aa7322b515f171aa949c1c59330f05d71b93da",
+                "url": "https://api.github.com/repos/jhu-idc/idc-ui-theme/zipball/245ef906440e78e540975dcbca88fbe9b96849b4",
+                "reference": "245ef906440e78e540975dcbca88fbe9b96849b4",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8089,7 +8089,7 @@
                 "source": "https://github.com/jhu-idc/idc-ui-theme/tree/main",
                 "issues": "https://github.com/jhu-idc/idc-ui-theme/issues"
             },
-            "time": "2022-02-15T20:02:46+00:00"
+            "time": "2022-02-16T15:29:36+00:00"
         },
         {
             "name": "jhu-idc/idc_defaults",


### PR DESCRIPTION
Addresses: https://github.com/jhu-idc/iDC-general/issues/456

- Turns off caching for the preprocess media hook to ensure the hook is run each page load that invokes the media template so that the necessary variables can be setup for the template logic
- Template logic conditionally displays the media in various formats for an islandora object, media page and taxonomy page