### PR TITLE
Address paged content fulltext search

### DIFF
--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d16a71dde80a38f6dcc4d1c492abeaad",
+    "content-hash": "641dd269604d01a5ef9d3a5744379af0",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -8159,12 +8159,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "c7d26ef94d453319fc3f5abd9ed0225dace3ff12"
+                "reference": "f1c03b351d59a68f788dba0ad17c4eedbba2fdad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/c7d26ef94d453319fc3f5abd9ed0225dace3ff12",
-                "reference": "c7d26ef94d453319fc3f5abd9ed0225dace3ff12",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/f1c03b351d59a68f788dba0ad17c4eedbba2fdad",
+                "reference": "f1c03b351d59a68f788dba0ad17c4eedbba2fdad",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8174,7 +8174,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2022-03-08T17:27:44+00:00"
+            "time": "2022-03-23T13:21:41+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",

--- a/codebase/composer.lock
+++ b/codebase/composer.lock
@@ -8159,12 +8159,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhu-idc/idc_ui_module.git",
-                "reference": "f1c03b351d59a68f788dba0ad17c4eedbba2fdad"
+                "reference": "90a7615b419ee9526a34979a682eb09a123fe99b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/f1c03b351d59a68f788dba0ad17c4eedbba2fdad",
-                "reference": "f1c03b351d59a68f788dba0ad17c4eedbba2fdad",
+                "url": "https://api.github.com/repos/jhu-idc/idc_ui_module/zipball/90a7615b419ee9526a34979a682eb09a123fe99b",
+                "reference": "90a7615b419ee9526a34979a682eb09a123fe99b",
                 "shasum": ""
             },
             "default-branch": true,
@@ -8174,7 +8174,7 @@
                 "source": "https://github.com/jhu-idc/idc_ui_module/tree/main",
                 "issues": "https://github.com/jhu-idc/idc_ui_module/issues"
             },
-            "time": "2022-03-23T13:21:41+00:00"
+            "time": "2022-03-23T19:05:41+00:00"
         },
         {
             "name": "jhu-idc/islandora_defaults",
@@ -21507,5 +21507,5 @@
         "php": ">=7.0.8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/codebase/config/sync/language.negotiation.yml
+++ b/codebase/config/sync/language.negotiation.yml
@@ -4,6 +4,7 @@ url:
   source: path_prefix
   prefixes:
     en: ''
+    '': null
   domains:
     en: ''
 selected_langcode: site_default

--- a/codebase/config/sync/search_api.index.default_solr_index.yml
+++ b/codebase/config/sync/search_api.index.default_solr_index.yml
@@ -10,6 +10,7 @@ dependencies:
     - token
     - content_translation
     - search_api
+    - idc_ui_module
   config:
     - field.storage.node.field_abstract
     - field.storage.node.field_access_rights
@@ -708,6 +709,10 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_years
+  idc_reverse_reference_parent_of_page:
+    label: 'Page metadata'
+    property_path: idc_reverse_reference_parent_of_page
+    type: text
   langcode:
     label: Language
     datasource_id: 'entity:node'
@@ -893,6 +898,7 @@ datasource_settings:
       default: true
       selected: {  }
 processor_settings:
+  add_page_media_to_paged_content: {  }
   add_url:
     weights:
       preprocess_index: -30

--- a/codebase/config/sync/views.view.solr_search_content.yml
+++ b/codebase/config/sync/views.view.solr_search_content.yml
@@ -42,6 +42,9 @@ dependencies:
     - field.storage.node.field_title_language
     - field.storage.node.field_years
     - search_api.index.default_solr_index
+    - taxonomy.vocabulary.islandora_models
+  content:
+    - 'taxonomy_term:islandora_models:111544e3-2c30-49f4-800e-9ad2ff99cebe'
   module:
     - controlled_access_terms
     - idc_ui_module
@@ -216,6 +219,52 @@ display:
           min_length: null
           fields: {  }
           plugin_id: search_api_fulltext
+        field_model:
+          id: field_model
+          table: search_api_index_default_solr_index
+          field: field_model
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: not
+          value:
+            - 29
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: islandora_models
+          hierarchy: false
+          error_message: true
+          plugin_id: search_api_term
       sorts:
         type:
           id: type
@@ -1194,6 +1243,7 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
+        - user
         - 'user.node_grants:view'
       cacheable: false
       max-age: -1
@@ -1257,6 +1307,7 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
+        - user
         - 'user.node_grants:view'
       cacheable: false
       max-age: -1
@@ -5611,6 +5662,7 @@ display:
         - url.query_args
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
+        - user
         - 'user.node_grants:view'
       tags:
         - 'config:field.storage.node.field_abstract'

--- a/end-to-end/tests/ui/advanced-search.spec.js
+++ b/end-to-end/tests/ui/advanced-search.spec.js
@@ -24,7 +24,7 @@ test('Proximity search and Clear button', async (t) => {
     .typeText(term1.proxyTerm.range, '3')
     .typeText(term1.proxyTerm.termB, 'item', { paste: true })
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(3);
+    .expect(Page.results.count).eql(1);
 
   await t.click(Page.addTermBtn);
 
@@ -39,12 +39,12 @@ test('Proximity search and Clear button', async (t) => {
     .typeText(term2.proxyTerm.range, '3')
     .typeText(term2.proxyTerm.termB, 'content', { paste: true })
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(1);
+    .expect(Page.results.count).eql(0);
 
   await t
     .click(term2.removeBtn)
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(3);
+    .expect(Page.results.count).eql(1);
 
   await t
     .click(Page.clearTerms)
@@ -82,7 +82,7 @@ test('Normal search', async (t) => {
     .expect(term2.nonproxyTerm.field.value).eql('')
     .typeText(term2.nonproxyTerm.term, 'page', { paste: true })
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(5);
+    .expect(Page.results.count).eql(3);
 });
 
 test('Can initiate search with Enter key', async (t) => {
@@ -104,8 +104,8 @@ test('Collection filter', async (t) => {
   await pager.goToPage(3);
 
   await t
-    .expect(Page.results.count).eql(4)
-    .expect(pager.pager.withText('24 of 24 items').exists).ok();
+    .expect(Page.results.count).eql(2)
+    .expect(pager.pager.withText('22 of 22 items').exists).ok();
 
   await t
     .click(Page.collectionsFilter.toggle) // Closed by default, need to open it first
@@ -139,13 +139,13 @@ test('Date filter and basic search', async (t) => {
   await t
     .typeText(term.nonproxyTerm.term, 'item', { paste: true})
     .click(Page.submitBtn)
-    .expect(Page.results.count).eql(7)
+    .expect(Page.results.count).eql(5)
     .typeText(Page.dateInput1, '2000', { paste: true})
     .pressKey('enter')
     .expect(Page.results.count).eql(2)
     .typeText(Page.dateInput2, '2010', { paste: true})
     .pressKey('tab')
-    .expect(Page.results.count).eql(5)
+    .expect(Page.results.count).eql(3)
     .click(Page.clearTerms)
     .expect(Page.results.count).eql(10);
 });
@@ -158,8 +158,8 @@ test('Date filter will reset current page', async (t) => {
   await t.expect(Page.results.count).eql(10);
   await pager.goToPage(3);
   await t
-    .expect(Page.results.count).eql(4)
-    .expect(pager.pager.withText('24 of 24 items').exists).ok();
+    .expect(Page.results.count).eql(2)
+    .expect(pager.pager.withText('22 of 22 items').exists).ok();
 
   await t
     .typeText(Page.dateInput1, '2000', { paste: true })

--- a/end-to-end/tests/ui/search-page.spec.js
+++ b/end-to-end/tests/ui/search-page.spec.js
@@ -10,7 +10,7 @@ test('Returns all items by default', async (t) => {
 
   await t
     .expect(Page.titleBar.withText('Search Results').exists).ok()
-    .expect(pager.pager.withText('of 24 items').exists).ok()
+    .expect(pager.pager.withText('of 22 items').exists).ok()
     .expect(pager.buttons.count).eql(5);
 });
 
@@ -24,9 +24,7 @@ test('Entering a new search term resets current page', async (t) => {
     .typeText(Page.searchInput, 'moo', { paste: true })
     .click(Page.searchSubmit)
     .expect(Page.results.count).eql(10)
-    .expect(pager.buttons.withText('2').exists).ok()
-    .click(pager.buttons.withText('2'))
-    .expect(Page.results.count).eql(2)
+    .expect(pager.buttons.withText('2').exists).notOk()
     // Second search for 'animal'
     .typeText(Page.searchInput, 'animal', { paste: true, replace: true })
     .click(Page.searchSubmit)
@@ -54,6 +52,6 @@ test('Selecting or deselecting a facet resets current page', async (t) => {
   // param were set to anything other than the first page, then no results
   // would be shown
   await t
-    .expect(pager.pager.withText('10 of 10 items').exists).ok()
-    .expect(Page.results.count).eql(10);
+    .expect(pager.pager.withText('8 of 8 items').exists).ok()
+    .expect(Page.results.count).eql(8);
 });


### PR DESCRIPTION
Fixes https://github.com/jhu-idc/iDC-general/issues/461
Fixes https://github.com/jhu-idc/iDC-general/issues/481
Fixes https://github.com/jhu-idc/iDC-general/issues/493

* Add custom Solr processor that will smush all extracted-text data onto the parent Paged Content to enable full text search against the Paged Content, rather than the Page
* Filter individual Pages in ALL search results
* Add hooks to automatically reindex Paged Content when child Pages have media added
* Update all collections search label