### PR TITLE
LAGS-154

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,8 @@ remove_standard_profile_references_from_config:
 .PHONY: config-export
 .SILENT: config-export
 config-export:
+	git checkout $(CURDIR)/codebase/config/sync/
+	docker-compose exec drupal bash -lc "bash /var/www/drupal/fix_permissions.sh /var/www/drupal/web nginx"
 	docker-compose exec drupal drush -l $(SITE) config:export -y
 
 # Import the sites configuration.

--- a/idc.Makefile
+++ b/idc.Makefile
@@ -79,7 +79,7 @@ warning-destroy-state:
 	@echo "3. Pull the latest images"
 	@echo "4. Re-install modules from composer.json"
 	@echo "WARNING: continue? [Y/n]"
-	@read line; if [ $$line != "Y" ]; then echo aborting; exit 1 ; fi
+	@read line; if [ $(shell echo $$line | tr A-Z a-z) != "y" ]; then echo aborting; exit 1 ; fi
 
 .PHONY: snapshot-empty
 .SILENT: snapshot-empty


### PR DESCRIPTION
## Merge [pull/309](https://github.com/jhu-idc/idc-isle-dc/pull/309) first

Fixes https://jhulibraries.atlassian.net/browse/LAGS-154

## Error message
```bash
 $ make config-export
 [notice] Differences of the active config to the export directory:
+------------+--------------------------+-----------+
| Collection | Config                   | Operation |
+------------+--------------------------+-----------+
|            | contact_storage.settings | Update    |
+------------+--------------------------+-----------+


 // The .yml files in your export directory (/var/www/drupal/config/sync) will be deleted and replaced with the active  
 // config.: yes.                                                                                                       

 [warning] unlink(/var/www/drupal/config/sync/at_core.settings.yml): Permission denied FileSystem.php:124
...
 [warning] unlink(/var/www/drupal/config/sync/workbench_access.settings.yml): Permission denied FileSystem.php:124
 [error]  The file permissions could not be set on /var/www/drupal/config/sync. 

In FileStorage.php line 86:
                                                                 
  Failed to create config directory /var/www/drupal/config/sync  
                                                                 

make: *** [Makefile:201: config-export] Error 1
```

## To test
Run `make clean` > `git checkout codebase/` > `make up` > `make config-export`