### PR TITLE
Add a case switch to prompt to avoid annoyances

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@ warn() {
       echo "the last snapshot."
       echo ""
       echo "WARNING: continue? [Y/n]"
-      read line; if [ $line != "Y" ]; then echo aborting; exit 1 ; fi
+      read line; line=$(echo "$line" | tr a-z A-Z); if [ $line != "Y" ]; then echo aborting; exit 1 ; fi
   fi
 }
 


### PR DESCRIPTION
Just run `make test` and it will prompt you. Entering lower case yes does not behave the same as uppercase yes. 

This PR converts the input to uppercase regardless.