### PR TITLE
Remove ref to Masonry submodule and added it to ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ screenshots/
 
 # Ignore docker images
 /images
+
+# Ignore Masonry
+codebase/web/libraries/masonry


### PR DESCRIPTION
Odd behavior of masonry. Git throws an error about a missing URL for masonry submodule. It isn't intended to be a submodule but was cloned in and the existence of the .git/ directory fools git into believing it's an undeclared submodule. This should fix that issue.